### PR TITLE
Provide fully context-aware completions

### DIFF
--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -4,7 +4,8 @@ module Curry.LanguageServer.Compiler (
     FileLoader,
     compileCurryFileWithDeps,
     compilationToMaybe,
-    failedCompilation
+    failedCompilation,
+    parseCurryModule
 ) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -125,7 +126,7 @@ loadAndCheckCurryModule opts fl m fp = do
     return ce
 
 -- | Loads a single module.
-loadCurryModule :: CO.Options -> CI.ModuleIdent -> String -> FilePath -> CYIO (CE.CompEnv (CS.Module()))
+loadCurryModule :: CO.Options -> CI.ModuleIdent -> String -> FilePath -> CYIO (CE.CompEnv (CS.Module ()))
 loadCurryModule opts m src fp = do
     -- Parse the module
     (lex, ast) <- parseCurryModule opts m src fp

--- a/src/Curry/LanguageServer/Features/Completion.hs
+++ b/src/Curry/LanguageServer/Features/Completion.hs
@@ -46,7 +46,6 @@ fetchCompletions store entry content pos = do
     
     let completions = maybe [] id
                    $  (takeIfNonEmpty $ expressionCompletions ast' pos)
-                  <|> (takeIfNonEmpty $ declarationCompletions ast' pos)
                   <|> (takeIfNonEmpty $ importCompletions store ast' pos)
                   <|> (takeIfNonEmpty $ generalCompletions env ast' pos query)
     
@@ -58,14 +57,7 @@ expressionCompletions :: Maybe (CS.Module a) -> J.Position -> [J.CompletionItem]
 expressionCompletions ast pos = do
     expr <- maybeToList $ elementAt pos =<< (expressions <$> ast)
     case expr of
-        -- TODO: Implement expression completions
-        _ -> []
-
-declarationCompletions :: Maybe (CS.Module a) -> J.Position -> [J.CompletionItem]
-declarationCompletions ast pos = do
-    expr <- maybeToList $ elementAt pos =<< (declarations <$> ast)
-    case expr of
-        -- TODO: Implement declaration completions
+        -- TODO: Implement expression-specific completions
         _ -> []
 
 importCompletions :: IndexStore -> Maybe (CS.Module a) -> J.Position -> [J.CompletionItem]
@@ -83,6 +75,8 @@ generalCompletions env ast pos query = rmDupsOn (^. J.label) $ filter (matchesQu
                                                              $ valueCompletions env ++ localCompletions ast pos
                                                                                     ++ typeCompletions env
                                                                                     ++ keywordCompletions
+
+-- TODO: Re-implement localCompletions using NestEnvs and bindings
 
 localCompletions :: Maybe (CS.Module a) -> J.Position -> [J.CompletionItem]
 localCompletions ast pos = declarationToCompletions =<< (elementsAt pos $ declarations =<< maybeToList ast)

--- a/src/Curry/LanguageServer/Features/Completion.hs
+++ b/src/Curry/LanguageServer/Features/Completion.hs
@@ -16,7 +16,7 @@ import Curry.LanguageServer.Logging
 import Curry.LanguageServer.Utils.Conversions (ppToText)
 import Curry.LanguageServer.Utils.General (rmDupsOn)
 import Curry.LanguageServer.Utils.Env (valueInfoType, typeInfoKind)
-import Curry.LanguageServer.Utils.Syntax (elementAt, ModuleAST, HasExpressions (..))
+import Curry.LanguageServer.Utils.Syntax (elementAt, ModuleAST, HasExpressions (..), HasDeclarations (..))
 import qualified Data.Map as M
 import Data.Maybe (maybeToList, isJust)
 import qualified Data.Text as T
@@ -27,7 +27,9 @@ fetchCompletions :: ModuleStoreEntry -> T.Text -> J.Position -> IO [J.Completion
 fetchCompletions entry query pos = do
     let env = compilerEnv entry
         ast = moduleAST entry
-        completions = (expressionCompletions ast pos) <|> (generalCompletions env query)
+        completions = expressionCompletions ast pos
+                  <|> declarationCompletions ast pos
+                  <|> generalCompletions env query
     
     logs INFO $ "fetchCompletions: Found " ++ show (length completions) ++ " completions with query '" ++ show query
     return completions
@@ -37,6 +39,13 @@ expressionCompletions ast pos = do
     expr <- maybeToList $ elementAt pos =<< (expressions <$> ast)
     case expr of
         -- TODO: Implement expression completions
+        _ -> []
+
+declarationCompletions :: Maybe ModuleAST -> J.Position -> [J.CompletionItem]
+declarationCompletions ast pos = do
+    expr <- maybeToList $ elementAt pos =<< (declarations <$> ast)
+    case expr of
+        -- TODO: Implement declaration completions
         _ -> []
 
 generalCompletions :: Maybe CE.CompilerEnv -> T.Text -> [J.CompletionItem]

--- a/src/Curry/LanguageServer/Features/Completion.hs
+++ b/src/Curry/LanguageServer/Features/Completion.hs
@@ -43,6 +43,8 @@ fetchCompletions store entry content pos = do
                 Right (_, m) -> Just m
                 _ -> Nothing
         _ -> return Nothing
+    
+    logs INFO $ "decl: " ++ show (elementAt pos =<< (\(CS.Module _ _ _ _ _ is _) -> is) <$> ast')
 
     let completions = expressionCompletions ast' pos
                   <|> declarationCompletions ast' pos
@@ -69,11 +71,8 @@ declarationCompletions ast pos = do
 importCompletions :: IndexStore -> Maybe (CS.Module a) -> J.Position -> [J.CompletionItem]
 importCompletions store ast pos = do
     CS.Module _ _ _ _ _ is _ <- maybeToList ast
-    CS.ImportDecl _ _ _ mid spec <- maybeToList $ elementAt pos is
-    case spec of
-        Just (CS.Importing _ is) | not (null is) -> case last is of
-            CS.Import _ ident -> moduleCompletions store
-        _ -> []
+    CS.ImportDecl _ mid _ _ _ <- maybeToList $ elementAt pos is
+    moduleCompletions store
 
 moduleCompletions :: IndexStore -> [J.CompletionItem]
 moduleCompletions store = moduleToCompletion <$> ((maybeToList . moduleAST) =<< snd <$> storedModules store)

--- a/src/Curry/LanguageServer/Features/Definition.hs
+++ b/src/Curry/LanguageServer/Features/Definition.hs
@@ -27,7 +27,7 @@ fetchDefinitions store entry pos = do
 
 definition :: IndexStore -> J.Position -> LM J.Location
 definition store pos = do
-    (qident, spi) <- findAtPos pos
+    (qident, spi) <- qualIdentAtPos pos
     qident' <- lift $ runMaybeT $ CT.origName <$> lookupValueInfo qident
     let ident  = CI.qidIdent  $  qident
         ident' = CI.qidIdent <$> qident'

--- a/src/Curry/LanguageServer/Features/Hover.hs
+++ b/src/Curry/LanguageServer/Features/Hover.hs
@@ -29,7 +29,7 @@ fetchHover entry pos = runMaybeT $ do
 
 hoverAt :: J.Position -> LM J.Hover
 hoverAt pos = do
-    (ident, spi) <- findAtPos pos
+    (ident, spi) <- qualIdentAtPos pos
     valueInfo <- lookupValueInfo ident
     let msg = J.HoverContents $ J.markedUpContent "curry" $ ppToText (CT.origName valueInfo) <> " :: " <> ppToText (valueInfoType valueInfo)
         range = currySpanInfo2Range spi

--- a/src/Curry/LanguageServer/Reactor.hs
+++ b/src/Curry/LanguageServer/Reactor.hs
@@ -16,7 +16,7 @@ import Curry.LanguageServer.Features.DocumentSymbols
 import Curry.LanguageServer.Features.Hover
 import Curry.LanguageServer.Features.WorkspaceSymbols
 import Curry.LanguageServer.Logging
-import Curry.LanguageServer.Utils.General (liftMaybe, slipr3, wordAtPos)
+import Curry.LanguageServer.Utils.General (liftMaybe, slipr3)
 import Curry.LanguageServer.Utils.Uri (filePathToNormalizedUri, normalizeUriWithPath)
 import Data.Default
 import qualified Data.Map as M
@@ -110,8 +110,7 @@ reactor lf rin = do
                 completions <- fmap (join . maybeToList) $ runMaybeT $ do
                     entry <- I.getModule normUri
                     vfile <- liftMaybe =<< (liftIO $ Core.getVirtualFileFunc lf normUri)
-                    query <- liftMaybe $ wordAtPos pos $ VFS.virtualFileText vfile
-                    liftIO $ fetchCompletions store entry query pos
+                    liftIO $ fetchCompletions store entry (VFS.virtualFileText vfile) pos
                 let maxCompletions = 25
                     items = take maxCompletions completions
                     incomplete = length completions > maxCompletions

--- a/src/Curry/LanguageServer/Reactor.hs
+++ b/src/Curry/LanguageServer/Reactor.hs
@@ -106,11 +106,12 @@ reactor lf rin = do
                     pos = req ^. J.params . J.position
                 normUri <- liftIO $ normalizeUriWithPath uri
                 vfile <- liftIO $ Core.getVirtualFileFunc lf normUri
+                store <- get
                 completions <- fmap (join . maybeToList) $ runMaybeT $ do
                     entry <- I.getModule normUri
                     vfile <- liftMaybe =<< (liftIO $ Core.getVirtualFileFunc lf normUri)
                     query <- liftMaybe $ wordAtPos pos $ VFS.virtualFileText vfile
-                    liftIO $ fetchCompletions entry query pos
+                    liftIO $ fetchCompletions store entry query pos
                 let maxCompletions = 25
                     items = take maxCompletions completions
                     incomplete = length completions > maxCompletions

--- a/src/Curry/LanguageServer/Utils/Env.hs
+++ b/src/Curry/LanguageServer/Utils/Env.hs
@@ -4,7 +4,7 @@ module Curry.LanguageServer.Utils.Env (
     LookupEnv,
     LM,
     runLM,
-    findAtPos,
+    qualIdentAtPos,
     valueInfoType,
     typeInfoKind
 ) where
@@ -12,6 +12,7 @@ module Curry.LanguageServer.Utils.Env (
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
+import qualified Curry.Syntax as CS
 import qualified Base.Kinds as CK
 import qualified Base.Types as CT
 import qualified CompilerEnv as CE
@@ -35,8 +36,8 @@ runLM :: LM a -> CE.CompilerEnv -> ModuleAST -> IO (Maybe a)
 runLM lm = curry $ runReaderT $ runMaybeT lm
 
 -- | Finds identifier and (occurrence) span info at a given position.
-findAtPos :: J.Position -> LM (CI.QualIdent, CSPI.SpanInfo)
-findAtPos pos = do
+qualIdentAtPos :: J.Position -> LM (CI.QualIdent, CSPI.SpanInfo)
+qualIdentAtPos pos = do
     (env, ast) <- lift ask
     let mident = moduleIdentifier ast
         exprIdent = joinFst $ qualIdentifier <.$> (withSpanInfo <$> (elementAt pos $ expressions ast))

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -6,6 +6,7 @@ module Curry.LanguageServer.Utils.General (
     nth,
     pair,
     dup,
+    guarded,
     wordAtIndex, wordAtPos,
     wordsWithSpaceCount,
     pointRange, emptyRange,
@@ -28,6 +29,7 @@ module Curry.LanguageServer.Utils.General (
     tripleToPair
 ) where
 
+import Control.Applicative
 import Control.Monad (join)
 import Control.Monad.Trans.Maybe
 import qualified Data.ByteString as B
@@ -69,6 +71,10 @@ pair x y = (x, y)
 -- | Duplicates.
 dup :: a -> (a, a)
 dup x = (x, x)
+
+-- | Creates a wrapped alternative value if it satisfies the predicate, otherwise empty
+guarded :: Alternative f => (a -> Bool) -> a -> f a
+guarded p x = if p x then pure x else empty
 
 -- | Finds the word at the given offset.
 wordAtIndex :: Int -> T.Text -> Maybe T.Text

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -6,6 +6,7 @@ module Curry.LanguageServer.Utils.Syntax (
     HasIdentifier (..),
     ModuleAST,
     elementAt,
+    elementContains,
     moduleIdentifier
 ) where
 

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -8,6 +8,7 @@ module Curry.LanguageServer.Utils.Syntax (
     HasIdentifier (..),
     ModuleAST,
     elementAt,
+    elementsAt,
     elementContains,
     moduleIdentifier
 ) where
@@ -24,9 +25,13 @@ import qualified Language.Haskell.LSP.Types as J
 
 type ModuleAST = CS.Module CT.PredType
 
--- | Fetches the element at the given position.
+-- | Fetches the innermost element at the given position.
 elementAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> Maybe e
-elementAt pos = lastSafe . filter (elementContains pos)
+elementAt pos = lastSafe . elementsAt pos
+
+-- | Fetches the elements at the given position.
+elementsAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> [e]
+elementsAt pos = filter (elementContains pos)
 
 -- | Tests whether the given element in the AST contains the given position.
 elementContains :: CSPI.HasSpanInfo e => J.Position -> e -> Bool

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -114,16 +114,19 @@ instance HasDeclarations CS.Decl where
         _                             -> []
 
 instance HasDeclarations CS.Equation where
-    declarations eqn = declarations =<< expressions eqn
+    declarations (CS.Equation _ _ rhs) = declarations rhs
 
 instance HasDeclarations CS.Rhs where
-    declarations rhs = declarations =<< expressions rhs
+    declarations rhs = case rhs of
+        CS.SimpleRhs _ _ e decls      -> (declarations e) ++ (declarations =<< decls)
+        CS.GuardedRhs _ _ conds decls -> (declarations =<< conds) ++ (declarations =<< decls)
 
 instance HasDeclarations CS.CondExpr where
     declarations ce = declarations =<< expressions ce
 
 instance HasDeclarations CS.Expression where
     declarations e = expressions e >>= \case
+        -- TODO: Declarations in do-statements etc.
         CS.Let _ _ ds e -> declarations =<< ds
         _               -> []
 

--- a/test/resources/Test.curry
+++ b/test/resources/Test.curry
@@ -1,7 +1,5 @@
 module Test where
 
-import Demo
-
 f x = case x of
     _ -> 3
-    _ -> 5
+    _ -> 4

--- a/test/resources/Test.curry
+++ b/test/resources/Test.curry
@@ -1,5 +1,5 @@
 module Test where
 
 f x = case x of
-    _ -> 3
+    _ -> let y = 4 in f y
     _ -> 4


### PR DESCRIPTION
### Fixes #5, #14

Provide context-aware completions.

**TODO:**
* [x] Complete imports
* [x] Re-parse the AST in completions to get a live view even if 
* [ ] Complete qualified identifiers (e.g. `Prelude.`)
* [ ] Provide completions for local variables by finding the current scope (generate a `NestEnv` ?)