### PR TITLE
Display initialization progress and index asynchronously

### DIFF
--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.Initialized (initializedHandler) where
 
+import Control.Monad (void, forM_)
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)
 import Curry.LanguageServer.Utils.Logging (infoM)
@@ -11,13 +12,22 @@ import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Message as J
+import System.FilePath (takeFileName)
 
 initializedHandler :: S.Handlers LSM
 initializedHandler = S.notificationHandler J.SMethod_Initialized $ \_nt -> do
     infoM "Building index store..."
     workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
     let folders = maybeToList . folderToPath =<< workspaceFolders
-    mapM_ addDirToIndexStore folders
+        folderCount = length folders
+
+    void $ S.withProgress "Curry: Adding folders" Nothing S.NotCancellable $ \update ->
+        forM_ (zip [0..] folders) $ \(i, fp) -> do
+            let percent = (i * 100) `div` folderCount
+                msg = T.pack $ "[" ++ show (i + 1) ++ " of " ++ show folderCount ++ "] " ++ takeFileName fp
+            update (S.ProgressAmount (Just $ fromIntegral percent) $ Just msg)
+            addDirToIndexStore fp
+
     count <- I.getModuleCount
     infoM $ "Indexed " <> T.pack (show count) <> " files"
     where folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri

--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.Initialized (initializedHandler) where
 
-import Control.Monad (void, forM_)
+import Control.Concurrent (forkIO)
+import Control.Monad (forM_, void)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Unlift (askRunInIO)
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)
 import Curry.LanguageServer.Utils.Logging (infoM)
@@ -16,21 +19,23 @@ import System.FilePath (takeFileName)
 
 initializedHandler :: S.Handlers LSM
 initializedHandler = S.notificationHandler J.SMethod_Initialized $ \_nt -> do
-    infoM "Building index store..."
-    workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
-    let folders = maybeToList . folderToPath =<< workspaceFolders
-        folderCount = length folders
+    runInIO <- askRunInIO
+    void $ liftIO $ forkIO $ runInIO $ S.withProgress "Curry: Adding folders" Nothing S.NotCancellable $ \update -> do
+        infoM "Building index store..."
+        workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
 
-    void $ S.withProgress "Curry: Adding folders" Nothing S.NotCancellable $ \update ->
+        let folders = maybeToList . folderToPath =<< workspaceFolders
+            folderCount = length folders
+
         forM_ (zip [0..] folders) $ \(i, fp) -> do
             let percent = (i * 100) `div` folderCount
                 msg = T.pack $ "[" ++ show (i + 1) ++ " of " ++ show folderCount ++ "] " ++ takeFileName fp
             update (S.ProgressAmount (Just $ fromIntegral percent) $ Just msg)
             addDirToIndexStore fp
 
-    count <- I.getModuleCount
-    infoM $ "Indexed " <> T.pack (show count) <> " files"
-    where folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri
+        count <- I.getModuleCount
+        infoM $ "Indexed " <> T.pack (show count) <> " files"
+        where folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri
 
 -- | Indexes a workspace folder recursively.
 addDirToIndexStore :: FilePath -> LSM ()


### PR DESCRIPTION
This causes e.g. VSCode to display initialization progress in the status bar. This PR also moves the indexing to a `forkIO` thread, since otherwise the progress will not show up.

![image](https://github.com/user-attachments/assets/45627a48-d2fb-4350-8c3d-4b6c62def896)

In the future we may also consider displaying more fine-grained progress.

One problem with asynchronous initialization is that the client will eagerly emit errors while the modules are still compiling (unless a `.curry/language-server` directory with previously compiled artifacts already exists):

![image](https://github.com/user-attachments/assets/217fa03a-b06b-4584-98f2-d81260ca62c9)

Hence why this PR is marked as a draft for now.