### PR TITLE
Add code lenses

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase, ScopedTypeVariables, OverloadedStrings #-}
 module Main where
 
 import Control.Monad.IO.Class (liftIO)
@@ -6,6 +6,7 @@ import Data.Default (Default (..))
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
 import Curry.LanguageServer.Handlers
+import Curry.LanguageServer.Handlers.Command (commands)
 import Curry.LanguageServer.Monad (runLSM, newLSStateVar)
 import System.Exit (ExitCode(ExitFailure), exitSuccess, exitWith)
 
@@ -24,7 +25,11 @@ runLanguageServer = do
         , S.doInitialize = const . pure . Right
         , S.staticHandlers = handlers
         , S.interpretHandler = \env -> S.Iso (\lsm -> runLSM lsm state env) liftIO
-        , S.options = S.defaultOptions { S.textDocumentSync = Just syncOptions }
+        , S.options = S.defaultOptions
+            { S.textDocumentSync = Just syncOptions
+            , S.executeCommandCommands = Just $ fst <$> commands
+            , S.serverInfo = Just $ J.ServerInfo "Curry Language Server" Nothing
+            }
         }
     where
         syncOptions = J.TextDocumentSyncOptions

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -1,6 +1,7 @@
 module Curry.LanguageServer.Handlers (handlers) where
 
 import Curry.LanguageServer.Handlers.CodeLens (codeLensHandler)
+import Curry.LanguageServer.Handlers.Command (commandHandler)
 import Curry.LanguageServer.Handlers.Completion (completionHandler)
 import Curry.LanguageServer.Handlers.Definition (definitionHandler)
 import Curry.LanguageServer.Handlers.DocumentSymbols (documentSymbolHandler)
@@ -16,6 +17,7 @@ handlers :: S.Handlers LSM
 handlers = mconcat
     [ -- Request handlers
       completionHandler
+    , commandHandler
     , definitionHandler
     , documentSymbolHandler
     , hoverHandler

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -1,5 +1,6 @@
 module Curry.LanguageServer.Handlers (handlers) where
 
+import Curry.LanguageServer.Handlers.CodeLens (codeLensHandler)
 import Curry.LanguageServer.Handlers.Completion (completionHandler)
 import Curry.LanguageServer.Handlers.Definition (definitionHandler)
 import Curry.LanguageServer.Handlers.DocumentSymbols (documentSymbolHandler)
@@ -19,6 +20,7 @@ handlers = mconcat
     , documentSymbolHandler
     , hoverHandler
     , workspaceSymbolHandler
+    , codeLensHandler
       -- Notification handlers
     , initializedHandler
     , didOpenHandler

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -1,0 +1,14 @@
+module Curry.LanguageServer.Handlers.CodeLens (codeLensHandler) where
+
+import Control.Monad.IO.Class (liftIO)
+import Curry.LanguageServer.Monad
+import qualified Language.LSP.Server as S
+import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
+import System.Log.Logger
+
+codeLensHandler :: S.Handlers LSM
+codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> do
+    liftIO $ debugM "cls.codeLens" "Processing code lens request"
+    let lenses = []
+    responder $ Right $ J.List lenses

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -1,7 +1,13 @@
 module Curry.LanguageServer.Handlers.CodeLens (codeLensHandler) where
 
+import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Maybe (runMaybeT)
+import qualified Curry.LanguageServer.IndexStore as I
 import Curry.LanguageServer.Monad
+import Curry.LanguageServer.Utils.Conversions (HasCodeLenses(..))
+import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
+import Data.Maybe (fromMaybe)
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
 import qualified Language.LSP.Types.Lens as J
@@ -10,5 +16,16 @@ import System.Log.Logger
 codeLensHandler :: S.Handlers LSM
 codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> do
     liftIO $ debugM "cls.codeLens" "Processing code lens request"
-    let lenses = []
-    responder $ Right $ J.List lenses
+    let J.CodeLensParams _ _ doc = req ^. J.params
+        uri = doc ^. J.uri
+    normUri <- liftIO $ normalizeUriWithPath uri
+    lenses <- runMaybeT $ do
+        entry <- I.getModule normUri
+        liftIO $ fetchCodeLenses entry
+    responder $ Right $ J.List $ fromMaybe [] lenses
+
+fetchCodeLenses :: I.ModuleStoreEntry -> IO [J.CodeLens]
+fetchCodeLenses entry = do
+    let lenses = maybe [] codeLenses $ I.mseModuleAST entry
+    debugM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lenses"
+    return lenses

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -26,6 +26,6 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
 
 fetchCodeLenses :: I.ModuleStoreEntry -> IO [J.CodeLens]
 fetchCodeLenses entry = do
-    let lenses = maybe [] codeLenses $ I.mseModuleAST entry
+    lenses <- maybe (pure []) codeLenses $ I.mseModuleAST entry
     debugM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lenses"
     return lenses

--- a/src/Curry/LanguageServer/Handlers/Command.hs
+++ b/src/Curry/LanguageServer/Handlers/Command.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Curry.LanguageServer.Handlers.Command (commandHandler) where
+module Curry.LanguageServer.Handlers.Command (commandHandler, commands) where
 
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)

--- a/src/Curry/LanguageServer/Handlers/Command.hs
+++ b/src/Curry/LanguageServer/Handlers/Command.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Curry.LanguageServer.Handlers.Command (commandHandler) where
+
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (liftIO)
+import Curry.LanguageServer.Monad
+import qualified Data.Aeson as A
+import qualified Data.Text as T
+import qualified Language.LSP.Server as S
+import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
+import System.Log.Logger
+
+commandHandler :: S.Handlers LSM
+commandHandler = S.requestHandler J.SWorkspaceExecuteCommand $ \req responder -> do
+    liftIO $ debugM "cls.command" "Processing command execution request"
+    let J.ExecuteCommandParams _ name args = req ^. J.params
+    res <- executeCommand name $ maybe [] (\(J.List as) -> as) args
+    responder res
+
+executeCommand :: T.Text -> [A.Value] -> LSM (Either J.ResponseError A.Value)
+executeCommand name args = case lookup name commands of
+    Just command -> command args
+    Nothing -> do
+        let msg = "Unknown command '" <> name <> "'"
+        liftIO $ warningM "cls.command" $ T.unpack msg
+        return $ Left $ J.ResponseError J.InvalidParams msg Nothing
+
+commands :: [(T.Text, [A.Value] -> LSM (Either J.ResponseError A.Value))]
+commands =
+    [ ("ping", \_args -> do
+        liftIO $ infoM "cls.command" "Pong!"
+        return $ Right A.Null)
+    ]

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -15,7 +15,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
 import qualified Curry.LanguageServer.IndexStore as I
 import Curry.LanguageServer.Utils.Conversions (ppToText)
-import Curry.LanguageServer.Utils.General (rmDupsOn, liftMaybe)
+import Curry.LanguageServer.Utils.General (rmDupsOn)
 import Curry.LanguageServer.Utils.Env (valueInfoType, typeInfoKind)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -12,7 +12,6 @@ import Data.Default (Default (..))
 import Data.Maybe (maybeToList, fromMaybe)
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
 import System.Log.Logger
 
 initializedHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Utils/Conversions.hs
+++ b/src/Curry/LanguageServer/Utils/Conversions.hs
@@ -267,13 +267,14 @@ class HasCodeLenses s where
 instance HasCodeLenses (CS.Module CT.PredType) where
     codeLenses (CS.Module _ _ _ _ _ _ decls) = typeHintLenses
         where typeSigIdents = S.fromList [i | CS.TypeSig _ is _ <- decls, i <- is]
-              untypedDecls = [(spi, t) | CS.FunctionDecl spi t i _ <- decls, i `S.notMember` typeSigIdents]
-              -- TODO: Move the command identifier ('decl.applyTypeHint') to some
-              --       central place to avoid repetition.
+              untypedDecls = [(spi, i, t) | CS.FunctionDecl spi t i _ <- decls, i `S.notMember` typeSigIdents]
               typeHintLenses = do
-                  (spi, t) <- untypedDecls
+                  (spi, i, t) <- untypedDecls
                   range <- maybeToList $ currySpanInfo2Range spi
-                  let command = J.Command (ppToText t) "decl.applyTypeHint" Nothing
+                  -- TODO: Move the command identifier ('decl.applyTypeHint') to some
+                  --       central place to avoid repetition.
+                  let text = ppToText i <> " :: " <> ppToText t
+                      command = J.Command text "decl.applyTypeHint" Nothing
                       lens = J.CodeLens range (Just command) Nothing
                   return lens
 

--- a/src/Curry/LanguageServer/Utils/Conversions.hs
+++ b/src/Curry/LanguageServer/Utils/Conversions.hs
@@ -14,6 +14,7 @@ module Curry.LanguageServer.Utils.Conversions (
     ppToText,
     HasDocumentSymbols (..),
     HasSymbolKind (..),
+    HasCodeLenses (..),
     HasWorkspaceSymbols (..),
     bindingToQualSymbols
 ) where
@@ -257,6 +258,12 @@ instance HasSymbolKind CETC.TypeInfo where
         CETC.AliasType _ _ _ _  -> J.SkInterface
         CETC.TypeClass _ _ _    -> J.SkInterface
         CETC.TypeVar _          -> J.SkTypeParameter
+
+class HasCodeLenses s where
+    codeLenses :: s -> [J.CodeLens]
+
+instance HasCodeLenses (CS.Module a) where
+    codeLenses = const [] -- TODO
 
 class HasWorkspaceSymbols s where
     workspaceSymbols :: s -> IO [J.SymbolInformation]


### PR DESCRIPTION
Add code lenses, e.g. for applying type hints, similar to how the Haskell language server handles this:

![image](https://user-images.githubusercontent.com/30873659/111322517-4f984780-8669-11eb-90ef-00deefc5e0c5.png)
