### PR TITLE
Add compiler monad and custom index symbol representation

### DIFF
--- a/src/Curry/LanguageServer/CPM/Monad.hs
+++ b/src/Curry/LanguageServer/CPM/Monad.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.CPM.Monad (CPMM, cpmm, runCPMM) where
 import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 
 -- | The monad for running the Curry Package Manager process.
-type CPMM a = ExceptT String IO a
+type CPMM = ExceptT String IO
 
 -- | Runs the monad used for running Curry Package Manager actions.
 runCPMM :: CPMM a -> IO (Either String a)

--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -31,7 +31,6 @@ import qualified Modules as CMD
 import qualified Transformations as CT
 import qualified Text.PrettyPrint as PP
 
-import Control.Applicative ((<|>))
 import Control.Monad (join)
 import Control.Monad.Trans.State (StateT (..))
 import Control.Monad.Trans.Maybe (MaybeT (..))

--- a/src/Curry/LanguageServer/Handlers/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeAction.hs
@@ -9,7 +9,7 @@ import Control.Lens ((^.))
 import Control.Monad (guard)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT)
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
 import Curry.LanguageServer.Utils.Conversions (currySpanInfo2Uri, currySpanInfo2Range, ppToText)
 import Curry.LanguageServer.Utils.General (rangeOverlaps)

--- a/src/Curry/LanguageServer/Handlers/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeAction.hs
@@ -36,7 +36,7 @@ codeActionHandler = S.requestHandler J.STextDocumentCodeAction $ \req responder 
 fetchCodeActions :: J.Range -> I.ModuleStoreEntry -> IO [J.CodeAction]
 fetchCodeActions range entry = do
     actions <- maybe (pure []) (codeActions range) $ I.mseModuleAST entry
-    debugM "cls.codeAction" $ "Found " ++ show (length actions) ++ " code actions"
+    debugM "cls.codeAction" $ "Found " ++ show (length actions) ++ " code action(s)"
     return actions
 
 class HasCodeActions s where

--- a/src/Curry/LanguageServer/Handlers/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeAction.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT)
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
-import Curry.LanguageServer.Utils.Conversions (currySpanInfo2Uri, currySpanInfo2Range, ppToText)
+import Curry.LanguageServer.Utils.Convert (currySpanInfo2Uri, currySpanInfo2Range, ppToText)
 import Curry.LanguageServer.Utils.General (rangeOverlaps)
 import Curry.LanguageServer.Utils.Sema (untypedTopLevelDecls)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeAction.hs
@@ -42,7 +42,7 @@ fetchCodeActions range entry = do
 class HasCodeActions s where
     codeActions :: J.Range -> s -> IO [J.CodeAction]
 
-instance HasCodeActions (CS.Module CT.PredType) where
+instance HasCodeActions (CS.Module (Maybe CT.PredType)) where
     codeActions range mdl@(CS.Module spi _ _ _ _ _ _) = do
         maybeUri <- liftIO $ runMaybeT (currySpanInfo2Uri spi)
 
@@ -50,7 +50,8 @@ instance HasCodeActions (CS.Module CT.PredType) where
         --       quick fixes along with the warning messages?
 
         let typeHintActions = do
-                (spi', i, t) <- untypedTopLevelDecls mdl
+                (spi', i, tp) <- untypedTopLevelDecls mdl
+                t <- maybeToList tp
                 range' <- maybeToList $ currySpanInfo2Range spi'
                 guard $ rangeOverlaps range range'
                 uri <- maybeToList maybeUri

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -34,7 +34,7 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
 fetchCodeLenses :: I.ModuleStoreEntry -> IO [J.CodeLens]
 fetchCodeLenses entry = do
     lenses <- maybe (pure []) codeLenses $ I.mseModuleAST entry
-    infoM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lenses"
+    infoM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lens(es)"
     return lenses
 
 class HasCodeLenses s where

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -34,7 +34,7 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
 fetchCodeLenses :: I.ModuleStoreEntry -> IO [J.CodeLens]
 fetchCodeLenses entry = do
     lenses <- maybe (pure []) codeLenses $ I.mseModuleAST entry
-    debugM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lenses"
+    infoM "cls.codeLens" $ "Found " ++ show (length lenses) ++ " code lenses"
     return lenses
 
 class HasCodeLenses s where

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -8,7 +8,7 @@ import qualified Base.Types as CT
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT)
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
 import Curry.LanguageServer.Utils.Conversions (currySpanInfo2Range, currySpanInfo2Uri, ppToText)
 import Curry.LanguageServer.Utils.Sema (untypedTopLevelDecls)

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -10,7 +10,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT)
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
-import Curry.LanguageServer.Utils.Conversions (currySpanInfo2Range, currySpanInfo2Uri, ppToText)
+import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range, currySpanInfo2Uri, ppToText)
 import Curry.LanguageServer.Utils.Sema (untypedTopLevelDecls)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import qualified Data.Aeson as A

--- a/src/Curry/LanguageServer/Handlers/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/CodeLens.hs
@@ -40,12 +40,13 @@ fetchCodeLenses entry = do
 class HasCodeLenses s where
     codeLenses :: s -> IO [J.CodeLens]
 
-instance HasCodeLenses (CS.Module CT.PredType) where
+instance HasCodeLenses (CS.Module (Maybe CT.PredType)) where
     codeLenses mdl@(CS.Module spi _ _ _ _ _ _) = do
         maybeUri <- liftIO $ runMaybeT (currySpanInfo2Uri spi)
 
         let typeHintLenses = do
-                (spi', i, t) <- untypedTopLevelDecls mdl
+                (spi', i, tp) <- untypedTopLevelDecls mdl
+                t <- maybeToList tp
                 range <- maybeToList $ currySpanInfo2Range spi'
                 uri <- maybeToList maybeUri
                 -- TODO: Move the command identifier ('decl.applyTypeHint') to some

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -87,8 +87,10 @@ data CompletionSymbol = CompletionSymbol
 toCompletionSymbols :: I.ModuleStoreEntry -> I.Symbol -> [CompletionSymbol]
 toCompletionSymbols entry s = do
     CS.Module _ _ _ mid _ imps _ <- maybeToList $ I.mseModuleAST entry
+    let pre = "Prelude"
+        impNames = S.fromList [ppToText mid' | CS.ImportDecl _ mid' _ _ _ <- imps]
     
-    if I.sParentIdent s == "Prelude" || I.sParentIdent s == ppToText mid
+    if (I.sParentIdent s == pre && pre `S.notMember` impNames) || I.sParentIdent s == ppToText mid
         then do
             m <- [Nothing, Just $ I.sParentIdent s]
             return CompletionSymbol

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -13,7 +13,7 @@ import Control.Lens ((^.))
 import Control.Monad (join)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Conversions (ppToText)
 import Curry.LanguageServer.Utils.Env (valueInfoType, typeInfoKind)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
@@ -67,7 +67,7 @@ pragmaCompletions query
 generalCompletions :: I.ModuleStoreEntry -> VFS.PosPrefixInfo -> IO [J.CompletionItem]
 generalCompletions entry query = do
     -- TODO: Context-awareness (through nested envs?)
-    let env                = maybeToList $ I.mseCompilerEnv entry
+    let env                = maybeToList Nothing -- FIXME
         valueCompletions   = toMatchingCompletions query $ nubOrdOn fst $ (CT.allBindings . CE.valueEnv)  =<< env
         typeCompletions    = toMatchingCompletions query $ nubOrdOn fst $ (CT.allBindings . CE.tyConsEnv) =<< env
         moduleCompletions  = toMatchingCompletions query $ nubOrd $ (maybeToList . CI.qidModule . fst) =<< (CT.allImports . CE.valueEnv) =<< env

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -156,7 +156,10 @@ instance ToCompletionItems CompletionSymbol where
                   I.TypeVar                                      -> J.CiVariable
                   I.Other                                        -> J.CiText
               detail = I.sPrintedType s
-              doc = Just $ T.intercalate ", " $ I.sConstructors s
+              doc = Just $ T.intercalate "\n" $ filter (not . T.null)
+                  [ if null edits then "" else "_requires import_"
+                  , T.intercalate ", " $ I.sConstructors s
+                  ]
 
 instance ToCompletionItems Keyword where
     -- | Creates a completion item from a keyword.

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -14,7 +14,7 @@ import Control.Monad (join)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
 import qualified Curry.LanguageServer.Index.Store as I
-import Curry.LanguageServer.Utils.Conversions (ppToText)
+import Curry.LanguageServer.Utils.Convert (ppToText)
 import Curry.LanguageServer.Utils.Env (valueInfoType, typeInfoKind)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -120,7 +120,7 @@ instance CompletionQueryFilter CompletionSymbol where
     matchesCompletionQuery query cms = fullPrefix `T.isPrefixOf` fullName
         where s = cmsSymbol cms
               moduleName = cmsModuleName cms
-              fullName = maybe (I.sQualIdent s) (\m -> m <> "." <> I.sIdent s) moduleName
+              fullName = maybe "" (<> ".") moduleName <> I.sIdent s
               fullPrefix | T.null (VFS.prefixModule query) = VFS.prefixText query
                          | otherwise                       = VFS.prefixModule query <> "." <> VFS.prefixText query
 
@@ -133,7 +133,7 @@ instance ToCompletionItems CompletionSymbol where
         where s = cmsSymbol cms
               moduleName = cmsModuleName cms
               edits = cmsImportEdits cms
-              fullName = maybe (I.sIdent s) (\m -> m <> "." <> I.sIdent s) moduleName
+              fullName = maybe "" (<> ".") moduleName <> I.sIdent s
               name = fromMaybe fullName $ T.stripPrefix (VFS.prefixModule query <> ".") fullName
               ciKind = case I.sKind s of
                   I.ValueFunction    | I.sArrowArity s == Just 0 -> J.CiConstant

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -85,7 +85,7 @@ data CompletionSymbol = CompletionSymbol
     }
 
 toCompletionSymbols :: I.ModuleStoreEntry -> I.Symbol -> [CompletionSymbol]
-toCompletionSymbols entry s = nubOrdOn (I.sQualIdent . cmsSymbol) $ do
+toCompletionSymbols entry s = do
     CS.Module _ _ _ mid _ imps _ <- maybeToList $ I.mseModuleAST entry
     
     if I.sParentIdent s == "Prelude" || I.sParentIdent s == ppToText mid

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -12,10 +12,10 @@ import Control.Monad.State.Class (get)
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Range)
-import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Syntax (HasIdentifiers (..))
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
+import Data.List.Extra (nubOrdOn)
 import Data.Maybe (maybeToList, fromMaybe, isNothing)
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -75,7 +75,7 @@ pragmaCompletions opts query
 generalCompletions :: CompletionOptions -> I.ModuleStoreEntry -> I.IndexStore -> VFS.PosPrefixInfo -> IO [J.CompletionItem]
 generalCompletions opts entry store query = do
     let localCompletions   = [] -- TODO: Context-awareness (through nested envs?)
-        symbolCompletions  = toMatchingCompletions opts query $ toCompletionSymbols entry =<< I.storedSymbolsWithPrefix (VFS.prefixText query) store -- TODO: Direct qualified symbol completions?
+        symbolCompletions  = toMatchingCompletions opts query $ toCompletionSymbols entry =<< nubOrdOn I.sQualIdent (I.storedSymbolsWithPrefix (VFS.prefixText query) store)
         keywordCompletions = toMatchingCompletions opts query keywords
         completions        = localCompletions ++ symbolCompletions ++ keywordCompletions
     infoM "cls.completions" $ "Found " ++ show (length completions) ++ " completions with prefix '" ++ show (VFS.prefixText query) ++ "'"

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -240,11 +240,11 @@ instance ToCompletionItems Keyword where
 instance ToCompletionItems Local where
     -- | Creates a completion item from a local variable.
     toCompletionItems _ _ (Local i) = [completionFrom label ciKind detail doc insertText insertTextFormat edits]
-        where label = ppToText i
+        where label = ppToText $ CI.unRenameIdent i
               ciKind = J.CiVariable
               detail = Nothing
               doc = Just "Local"
-              insertText = Just $ ppToText i
+              insertText = Just label
               insertTextFormat = Just J.PlainText
               edits = Nothing
 

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -90,11 +90,10 @@ toCompletionSymbols entry s = nubOrdOn (I.sQualIdent . cmsSymbol) $ do
     
     if I.sParentIdent s == "Prelude" || I.sParentIdent s == ppToText mid
         then [ CompletionSymbol
-                   { cmsSymbol = s
-                   , cmsModuleName = Nothing
-                   , cmsImportEdits = Nothing
-                   }
-             ]
+                { cmsSymbol = s
+                , cmsModuleName = m
+                , cmsImportEdits = Nothing
+                } | m <- [Nothing, Just $ I.sParentIdent s]]
         else do
             CS.ImportDecl _ mid' isQual alias spec <- imps
             let isImported = case spec of
@@ -102,7 +101,7 @@ toCompletionSymbols entry s = nubOrdOn (I.sQualIdent . cmsSymbol) $ do
                     Just (CS.Hiding _ is)    -> flip S.notMember $ S.fromList $ ppToText <$> (identifiers =<< is)
                     Nothing                  -> const True
                 moduleNames = (Just $ ppToText $ fromMaybe mid' alias) : [Nothing | not isQual]
-            (\m -> CompletionSymbol
+            [CompletionSymbol
                 { cmsSymbol = s
                 , cmsModuleName = m
                 , cmsImportEdits = if isImported $ I.sIdent s
@@ -114,7 +113,7 @@ toCompletionSymbols entry s = nubOrdOn (I.sQualIdent . cmsSymbol) $ do
                                                                                                     edit = J.TextEdit range text
                                                                                                 in [edit]
                         _                                                                    -> []
-                }) <$> moduleNames
+                } | m <- moduleNames]
 
 class CompletionQueryFilter a where
     matchesCompletionQuery :: VFS.PosPrefixInfo -> a -> Bool

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -80,7 +80,7 @@ importCompletions opts store query = do
         moduleCompletions  = toMatchingCompletions opts query $ (\s -> CompletionSymbol s Nothing Nothing) <$> modules
         keywordCompletions = toMatchingCompletions opts query $ Keyword <$> ["qualified", "as", "hiding"]
         completions        = moduleCompletions ++ keywordCompletions
-    infoM "cls.completions" $ "Found " ++ show (length completions) ++ " import completions"
+    infoM "cls.completions" $ "Found " ++ show (length completions) ++ " import completion(s)"
     return completions
 
 generalCompletions :: CompletionOptions -> I.ModuleStoreEntry -> I.IndexStore -> VFS.PosPrefixInfo -> IO [J.CompletionItem]
@@ -89,7 +89,7 @@ generalCompletions opts entry store query = do
         symbolCompletions  = toMatchingCompletions opts query $ toCompletionSymbols entry =<< nubOrdOn I.sQualIdent (I.storedSymbolsWithPrefix (VFS.prefixText query) store)
         keywordCompletions = toMatchingCompletions opts query keywords
         completions        = localCompletions ++ symbolCompletions ++ keywordCompletions
-    infoM "cls.completions" $ "Found " ++ show (length completions) ++ " completions with prefix '" ++ show (VFS.prefixText query) ++ "'"
+    infoM "cls.completions" $ "Found " ++ show (length completions) ++ " completion(s) with prefix '" ++ show (VFS.prefixText query) ++ "'"
     return completions
     where keywords = Keyword <$> ["case", "class", "data", "default", "deriving", "do", "else", "external", "fcase", "free", "if", "import", "in", "infix", "infixl", "infixr", "instance", "let", "module", "newtype", "of", "then", "type", "where", "as", "ccall", "forall", "hiding", "interface", "primitive", "qualified"]
 

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -15,7 +15,6 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Convert (ppToText)
-import Curry.LanguageServer.Utils.Lookup (valueInfoType, typeInfoKind)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
 import Data.List.Extra (nubOrd, nubOrdOn)
@@ -127,8 +126,7 @@ instance ToCompletionItem (CI.QualIdent, CEV.ValueInfo) where
                                     | otherwise -> J.CiConstant
                       where arity = CTY.arrowArity $ CTY.rawType t
                   CEV.Label _ _ _              -> J.CiFunction -- Arity is always 1 for record labels
-              vtype = valueInfoType vinfo
-              detail = Just $ ppToText vtype
+              detail = Nothing -- FIXME: Show type
               doc = case vinfo of
                   CEV.DataConstructor _ _ recordLabels _ -> Just $ T.intercalate ", " $ ppToText <$> recordLabels
                   _                                      -> Nothing
@@ -144,8 +142,7 @@ instance ToCompletionItem (CI.QualIdent, CETC.TypeInfo) where
                   CETC.AliasType _ _ _ _  -> J.CiInterface
                   CETC.TypeClass _ _ _    -> J.CiInterface
                   CETC.TypeVar _          -> J.CiTypeParameter
-              tkind = typeInfoKind tinfo
-              detail = Just $ ppToText tkind
+              detail = Nothing -- FIXME: Show kind
               doc = case tinfo of
                   CETC.DataType _ _ cs    -> Just $ T.intercalate ", " $ ppToText <$> CTY.constrIdent <$> cs
                   CETC.RenamingType _ _ c -> Just $ ppToText c

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -136,7 +136,7 @@ instance ToCompletionItems CompletionSymbol where
         where s = cmsSymbol cms
               moduleName = cmsModuleName cms
               edits = cmsImportEdits cms
-              fullName = maybe (I.sQualIdent s) (\m -> m <> "." <> I.sIdent s) moduleName
+              fullName = maybe (I.sIdent s) (\m -> m <> "." <> I.sIdent s) moduleName
               name = fromMaybe fullName $ T.stripPrefix (VFS.prefixModule query <> ".") fullName
               ciKind = case I.sKind s of
                   I.ValueFunction    | I.sArrowArity s == Just 0 -> J.CiConstant

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -16,6 +16,7 @@ import Curry.LanguageServer.Utils.Syntax (HasIdentifiers (..))
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
 import Data.Maybe (maybeToList, fromMaybe, isNothing)
+import Data.List.Extra (nubOrdOn)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
@@ -84,7 +85,7 @@ data CompletionSymbol = CompletionSymbol
     }
 
 toCompletionSymbols :: I.ModuleStoreEntry -> I.Symbol -> [CompletionSymbol]
-toCompletionSymbols entry s = do
+toCompletionSymbols entry s = nubOrdOn (I.sQualIdent . cmsSymbol) $ do
     CS.Module _ _ _ mid _ imps _ <- maybeToList $ I.mseModuleAST entry
     
     if I.sParentIdent s == "Prelude" || I.sParentIdent s == ppToText mid

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -157,7 +157,7 @@ instance ToCompletionItems CompletionSymbol where
                   I.TypeVar                                      -> J.CiVariable
                   I.Other                                        -> J.CiText
               detail = I.sPrintedType s
-              doc = Just $ T.intercalate "\n" $ filter (not . T.null)
+              doc = Just $ T.intercalate "\n\n" $ filter (not . T.null)
                   [ if isNothing edits then "" else "_requires import_"
                   , T.intercalate ", " $ I.sConstructors s
                   ]
@@ -185,7 +185,7 @@ completionFrom l k d c es = J.CompletionItem label kind tags detail doc deprecat
         kind = Just k
         tags = Nothing
         detail = d
-        doc = J.CompletionDocString <$> c
+        doc = J.CompletionDocMarkup . J.MarkupContent J.MkMarkdown <$> c
         deprecated = Just False
         preselect = Nothing
         sortText = Nothing

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -64,11 +64,8 @@ pragmaCompletions query
 
 generalCompletions :: I.ModuleStoreEntry -> I.IndexStore -> VFS.PosPrefixInfo -> IO [J.CompletionItem]
 generalCompletions entry store query = do
-    -- TODO: Filter only imported symbols (and otherwise attach an edit to import them)
-    -- TODO: Qualified symbols
-    -- TODO: Qualified symbols from renamed imports
     let localCompletions   = [] -- TODO: Context-awareness (through nested envs?)
-        symbolCompletions  = toMatchingCompletions query $ toCompletionSymbols entry =<< I.storedSymbols store -- TODO: Filter directly at store level
+        symbolCompletions  = toMatchingCompletions query $ toCompletionSymbols entry =<< I.storedSymbolsWithPrefix (VFS.prefixText query) store -- TODO: Direct qualified symbol completions?
         keywordCompletions = toMatchingCompletions query keywords
         completions        = localCompletions ++ symbolCompletions ++ keywordCompletions
     infoM "cls.completions" $ "Found " ++ show (length completions) ++ " completions with prefix '" ++ show (VFS.prefixText query) ++ "'"

--- a/src/Curry/LanguageServer/Handlers/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/Completion.hs
@@ -15,7 +15,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Convert (ppToText)
-import Curry.LanguageServer.Utils.Env (valueInfoType, typeInfoKind)
+import Curry.LanguageServer.Utils.Lookup (valueInfoType, typeInfoKind)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
 import Data.List.Extra (nubOrd, nubOrdOn)

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -6,7 +6,7 @@ import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
-import Curry.LanguageServer.Index.Lookup
+import Curry.LanguageServer.Index.Resolve
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -1,16 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.Definition (definitionHandler) where
 
--- Curry Compiler Libraries + Dependencies
-import qualified Curry.Base.Ident as CI
-import qualified Curry.Syntax as CS
-
 import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
-import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Index.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -10,7 +10,7 @@ import Control.Applicative ((<|>))
 import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Conversions
 import Curry.LanguageServer.Utils.Env
 import Curry.LanguageServer.Utils.General (liftMaybe)
@@ -42,7 +42,7 @@ definitionHandler = S.requestHandler J.STextDocumentDefinition $ \req responder 
 fetchDefinitions :: I.IndexStore -> I.ModuleStoreEntry -> J.Position -> IO [J.LocationLink]
 fetchDefinitions store entry pos = do
     defs <- runMaybeT $ do ast <- liftMaybe $ I.mseModuleAST entry
-                           env <- liftMaybe $ I.mseCompilerEnv entry
+                           env <- liftMaybe Nothing -- FIXME
                            MaybeT $ runLM (definition store pos) env ast
     infoM "cls.definition" $ "Found " ++ show defs
     return $ maybeToList defs

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -11,7 +11,7 @@ import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert
-import Curry.LanguageServer.Utils.Lookup
+import Curry.LanguageServer.Index.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert
-import Curry.LanguageServer.Utils.Env
+import Curry.LanguageServer.Utils.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -16,7 +16,7 @@ import Curry.LanguageServer.Utils.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
-import Data.List (find)
+import Data.List (find, sortOn)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, maybeToList, mapMaybe, listToMaybe)
 import qualified Data.Text as T
@@ -62,4 +62,7 @@ definitions store pos = do
     return [J.LocationLink srcRange destUri destRange destRange | J.Location destUri destRange <- locs]
 
 definitionsInStore :: I.IndexStore -> CI.QualIdent -> [J.Location]
-definitionsInStore store qid = mapMaybe I.sLocation $ filter I.sIsFromCurrySource $ I.storedSymbolsByQualIdent qid store
+definitionsInStore store qid = mapMaybe I.sLocation symbols'
+    where symbols = I.storedSymbolsByQualIdent qid store
+          symbols' | any I.sIsFromCurrySource symbols = filter I.sIsFromCurrySource symbols
+                   | otherwise                        = symbols

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -48,7 +48,10 @@ definition :: I.IndexStore -> J.Position -> LM J.LocationLink
 definition store pos = do
     mid <- getModuleIdentifier
     (qid, _) <- liftMaybe =<< findQualIdentAtPos pos
-    let qid' = CI.qualQualify mid qid
+    -- TODO: This is not quite correct yet, since the AST may contain
+    --       unqualified QualIdents that actually refer to some imported
+    --       symbol rather than something from the current module.
+    let qid' = qid { CI.qidModule = Just $ fromMaybe mid $ CI.qidModule qid }
     liftIO $ infoM "cls.definition" $ "Looking for " ++ ppToString qid'
     J.Location destUri destRange <- liftMaybe $ definitionInStore store qid'
     srcRange <- ((^. J.range) <$>) <$> (liftIO $ runMaybeT $ currySpanInfo2Location qid')

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -11,6 +11,7 @@ import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
+import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.Env
 import Curry.LanguageServer.Utils.General (liftMaybe)
@@ -18,7 +19,7 @@ import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
 import Data.List (find)
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, maybeToList)
+import Data.Maybe (fromMaybe, maybeToList, mapMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
@@ -56,7 +57,7 @@ definition store pos = do
 
 definitionInStore :: I.IndexStore -> CI.QualIdent -> Maybe J.Location
 definitionInStore store qident = find (isCurrySource . (^. J.uri)) locations
-    where locations = (^. J.location) . I.sseSymbol <$> I.storedSymbolsByQualIdent qident store
+    where locations = mapMaybe I.sLocation $ I.storedSymbolsByQualIdent qident store
           isCurrySource uri = ".curry" `T.isSuffixOf` J.getUri uri
 
 definitionInEnvs :: CI.QualIdent -> LM (Maybe J.Location)

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -40,8 +40,7 @@ definitionHandler = S.requestHandler J.STextDocumentDefinition $ \req responder 
 fetchDefinitions :: I.IndexStore -> I.ModuleStoreEntry -> J.Position -> IO [J.LocationLink]
 fetchDefinitions store entry pos = do
     defs <- runMaybeT $ do ast <- liftMaybe $ I.mseModuleAST entry
-                           env <- liftMaybe Nothing -- FIXME
-                           MaybeT $ runLM (definition store pos) env ast
+                           MaybeT $ runLM (definition store pos) ast
     infoM "cls.definition" $ "Found " ++ show defs
     return $ maybeToList defs
 

--- a/src/Curry/LanguageServer/Handlers/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/Definition.hs
@@ -11,7 +11,7 @@ import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
-import Curry.LanguageServer.Utils.Conversions
+import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.Env
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/Diagnostics.hs
+++ b/src/Curry/LanguageServer/Handlers/Diagnostics.hs
@@ -4,7 +4,7 @@ module Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics, fetchDiagnost
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Curry.LanguageServer.Index.Store (ModuleStoreEntry (..))
-import Curry.LanguageServer.Utils.Conversions
+import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.Uri (normalizedUriToFilePath)
 import Curry.LanguageServer.Monad
 import qualified Data.Map as M

--- a/src/Curry/LanguageServer/Handlers/Diagnostics.hs
+++ b/src/Curry/LanguageServer/Handlers/Diagnostics.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics, fetchDiagnost
 
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
-import Curry.LanguageServer.IndexStore (ModuleStoreEntry (..))
+import Curry.LanguageServer.Index.Store (ModuleStoreEntry (..))
 import Curry.LanguageServer.Utils.Conversions
 import Curry.LanguageServer.Utils.Uri (normalizedUriToFilePath)
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/DocumentSymbols.hs
+++ b/src/Curry/LanguageServer/Handlers/DocumentSymbols.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.Handlers.DocumentSymbols (documentSymbolHandler) whe
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Maybe
 import Control.Lens ((^.))
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Utils.Conversions (HasDocumentSymbols(..))
 import Curry.LanguageServer.Monad

--- a/src/Curry/LanguageServer/Handlers/DocumentSymbols.hs
+++ b/src/Curry/LanguageServer/Handlers/DocumentSymbols.hs
@@ -5,7 +5,7 @@ import Control.Monad.Trans.Maybe
 import Control.Lens ((^.))
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
-import Curry.LanguageServer.Utils.Conversions (HasDocumentSymbols(..))
+import Curry.LanguageServer.Utils.Convert (HasDocumentSymbols(..))
 import Curry.LanguageServer.Monad
 import Data.Maybe (fromMaybe)
 import qualified Language.LSP.Server as S

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans (liftIO, lift)
 import Control.Monad.Trans.Maybe
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Convert
-import Curry.LanguageServer.Utils.Env
+import Curry.LanguageServer.Utils.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Syntax (TypedSpanInfo (..))
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -8,7 +8,7 @@ import Control.Applicative ((<|>))
 import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO, lift)
 import Control.Monad.Trans.Maybe
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Conversions
 import Curry.LanguageServer.Utils.Env
 import Curry.LanguageServer.Utils.General (liftMaybe)
@@ -35,7 +35,7 @@ hoverHandler = S.requestHandler J.STextDocumentHover $ \req responder -> do
 fetchHover :: I.ModuleStoreEntry -> J.Position -> IO (Maybe J.Hover)
 fetchHover entry pos = runMaybeT $ do
     ast <- liftMaybe $ I.mseModuleAST entry
-    env <- liftMaybe $ I.mseCompilerEnv entry
+    env <- liftMaybe Nothing -- FIXME
     hover <- MaybeT $ runLM (hoverAt pos) env ast
     liftIO $ infoM "cls.hover" $ "Found " ++ show hover
     return hover

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -9,7 +9,7 @@ import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO, lift)
 import Control.Monad.Trans.Maybe
 import qualified Curry.LanguageServer.Index.Store as I
-import Curry.LanguageServer.Utils.Conversions
+import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.Env
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Syntax (TypedSpanInfo (..))

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.Hover (hoverHandler) where
 
--- Curry Compiler Libraries + Dependencies
-import qualified Base.TopEnv as CT
-
-import Control.Applicative ((<|>))
 import Control.Lens ((^.))
 import Control.Monad.Trans (liftIO, lift)
 import Control.Monad.Trans.Maybe
@@ -35,30 +31,12 @@ hoverHandler = S.requestHandler J.STextDocumentHover $ \req responder -> do
 fetchHover :: I.ModuleStoreEntry -> J.Position -> IO (Maybe J.Hover)
 fetchHover entry pos = runMaybeT $ do
     ast <- liftMaybe $ I.mseModuleAST entry
-    env <- liftMaybe Nothing -- FIXME
-    hover <- MaybeT $ runLM (hoverAt pos) env ast
+    hover <- MaybeT $ runLM (hoverAt pos) ast
     liftIO $ infoM "cls.hover" $ "Found " ++ show hover
     return hover
 
 hoverAt :: J.Position -> LM J.Hover
-hoverAt pos = ((<|>) <$> qualIdentHover pos <*> typedSpanInfoHover pos) >>= liftMaybe
-
-qualIdentHover :: J.Position -> LM (Maybe J.Hover)
-qualIdentHover pos = runMaybeT $ do
-    (ident, spi) <- MaybeT $ findQualIdentAtPos pos
-    valueInfo <- lift $ lookupValueInfo ident
-    typeInfo <- lift $ lookupTypeInfo ident
-    mid <- lift getModuleIdentifier
-
-    let valueMsg = (\v -> ppToText (CT.origName v) <> " :: " <> ppTypeSchemeToText mid (valueInfoType v)) <$> valueInfo
-        typeMsg  = (\t -> ppToText (CT.origName t) <> " :: " <> ppToText               (typeInfoKind t))  <$> typeInfo
-
-    msg <- liftMaybe $ valueMsg <|> typeMsg
-
-    let contents = J.HoverContents $ J.markedUpContent "curry" msg
-        range = currySpanInfo2Range spi
-
-    return $ J.Hover contents range
+hoverAt pos = typedSpanInfoHover pos >>= liftMaybe
 
 typedSpanInfoHover :: J.Position -> LM (Maybe J.Hover)
 typedSpanInfoHover pos = runMaybeT $ do

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -8,7 +8,7 @@ import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Maybe
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Convert (ppPredTypeToText, currySpanInfo2Range)
-import Curry.LanguageServer.Utils.Lookup
+import Curry.LanguageServer.Index.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
 import Curry.LanguageServer.Utils.Syntax (TypedSpanInfo (..), ModuleAST, moduleIdentifier)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -12,7 +12,8 @@ import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (ppPredTypeToText, currySpanInfo2Range)
 import Curry.LanguageServer.Index.Lookup
 import Curry.LanguageServer.Utils.General (liftMaybe)
-import Curry.LanguageServer.Utils.Syntax (TypedSpanInfo (..), ModuleAST, moduleIdentifier)
+import Curry.LanguageServer.Utils.Syntax (ModuleAST, moduleIdentifier)
+import Curry.LanguageServer.Utils.Sema (TypedSpanInfo (..))
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Monad
 import Data.Maybe (listToMaybe)

--- a/src/Curry/LanguageServer/Handlers/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/Hover.hs
@@ -10,8 +10,9 @@ import Control.Monad.Trans.Maybe
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (ppPredTypeToText, currySpanInfo2Range)
-import Curry.LanguageServer.Index.Lookup
+import Curry.LanguageServer.Index.Resolve (resolveQualIdentAtPos)
 import Curry.LanguageServer.Utils.General (liftMaybe)
+import Curry.LanguageServer.Utils.Lookup (findTypeAtPos)
 import Curry.LanguageServer.Utils.Syntax (ModuleAST, moduleIdentifier)
 import Curry.LanguageServer.Utils.Sema (TypedSpanInfo (..))
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -4,7 +4,7 @@ import Control.Monad.IO.Class (liftIO)
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.LogHandler (setupLogging)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
 import Data.Default (Default (..))
 import Data.Maybe (maybeToList, fromMaybe)

--- a/src/Curry/LanguageServer/Handlers/TextDocument.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument.hs
@@ -12,7 +12,7 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
 import Curry.LanguageServer.Utils.Concurrent (debounceConst)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)

--- a/src/Curry/LanguageServer/Handlers/WorkspaceSymbols.hs
+++ b/src/Curry/LanguageServer/Handlers/WorkspaceSymbols.hs
@@ -2,7 +2,7 @@ module Curry.LanguageServer.Handlers.WorkspaceSymbols (workspaceSymbolHandler) w
 
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S

--- a/src/Curry/LanguageServer/Handlers/WorkspaceSymbols.hs
+++ b/src/Curry/LanguageServer/Handlers/WorkspaceSymbols.hs
@@ -3,7 +3,9 @@ module Curry.LanguageServer.Handlers.WorkspaceSymbols (workspaceSymbolHandler) w
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import qualified Curry.LanguageServer.Index.Store as I
+import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Monad
+import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
@@ -22,6 +24,25 @@ workspaceSymbolHandler = S.requestHandler J.SWorkspaceSymbol $ \req responder ->
 fetchWorkspaceSymbols :: I.IndexStore -> T.Text -> IO [J.SymbolInformation]
 fetchWorkspaceSymbols store query = do
     debugM "cls.workspaceSymbols" $ "Searching " ++ show (I.storedSymbolCount store) ++ " symbol(s)..."
-    let symbols = I.sseSymbol <$> I.storedSymbolsWithPrefix query store
+    let symbols = mapMaybe toWorkspaceSymbol $ I.storedSymbolsWithPrefix query store
     infoM "cls.workspaceSymbols" $ "Found " ++ show (length symbols) ++ " symbol(s)"
     return symbols
+
+toWorkspaceSymbol :: I.Symbol -> Maybe J.SymbolInformation
+toWorkspaceSymbol s = (\loc -> J.SymbolInformation name kind deprecated loc containerName) <$> I.sLocation s
+    where name = I.sIdent s
+          kind = case I.sKind s of
+              I.ValueFunction    | I.sArrowArity s == Just 0 -> J.SkConstant
+                                 | otherwise                 -> J.SkFunction
+              I.ValueConstructor | I.sArrowArity s == Just 0 -> J.SkEnumMember
+                                 | otherwise                 -> J.SkConstructor
+              I.Module                                       -> J.SkModule
+              I.TypeData | length (I.sConstructors s) == 1   -> J.SkStruct
+                         | otherwise                         -> J.SkEnum
+              I.TypeNew                                      -> J.SkStruct
+              I.TypeAlias                                    -> J.SkInterface
+              I.TypeClass                                    -> J.SkInterface
+              I.TypeVar                                      -> J.SkVariable
+              I.Other                                        -> J.SkNamespace
+          deprecated = Just False
+          containerName = Just $ I.sParentIdent s

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -38,6 +38,7 @@ makeValueSymbol k q t = do
     return def
         { sKind = k
         , sQualIdent = ppToText q
+        , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText t
         , sArrowArity = Just $ CT.arrowArity $ CT.rawType t
         , sLocation = loc
@@ -49,6 +50,7 @@ makeTypeSymbol k q k' = do
     return def
         { sKind = k
         , sQualIdent = ppToText q
+        , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText k'
         , sArrowArity = Just $ CK.kindArity k'
         , sLocation = loc

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -69,6 +69,7 @@ makeValueSymbol k q t = do
         , sQualIdent = ppToText q
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText t
+        , sPrintedArgumentTypes = ppToText <$> CT.arrowArgs (CT.rawType t)
         , sArrowArity = Just $ CT.arrowArity $ CT.rawType t
         , sLocation = loc
         }
@@ -81,6 +82,7 @@ makeTypeSymbol k q k' = do
         , sQualIdent = ppToText q
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText k'
+        , sPrintedArgumentTypes = ppToText <$> CK.kindArgs k'
         , sArrowArity = Just $ CK.kindArity k'
         , sLocation = loc
         }

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -12,7 +12,10 @@ import qualified Env.Value as CEV
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Curry.LanguageServer.Index.Symbol (Symbol (..), SymbolKind (..))
 import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
+import Curry.LanguageServer.Utils.General (lastSafe)
 import Data.Default (Default (..))
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
 
 class ToSymbol s where
     toSymbol :: s -> IO (Maybe Symbol)
@@ -39,7 +42,7 @@ instance ToSymbol CI.ModuleIdent where
         return $ Just def
             { sKind = Module
             , sQualIdent = ppToText mid
-            , sIdent = ppToText mid
+            , sIdent = T.pack $ fromMaybe "" $ lastSafe $ CI.midQualifiers mid
             , sLocation = loc
             }
 

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE OverloadedStrings, FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings, FlexibleInstances, ViewPatterns #-}
 module Curry.LanguageServer.Index.Convert (
     ToSymbols (..)
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
+import qualified Base.TopEnv as CTE
 import qualified Base.Types as CT
 import qualified Base.Kinds as CK
 import qualified Env.TypeConstructor as CETC
@@ -23,20 +24,26 @@ class ToSymbols s where
     toSymbols :: s -> IO [Symbol]
     
 instance ToSymbols (CI.QualIdent, CEV.ValueInfo) where
-    toSymbols (q, vinfo) = pure <$> case vinfo of
-        CEV.DataConstructor _ _ ls t  -> (\s -> s { sConstructors = ppToText <$> ls })
-                                     <$> makeValueSymbol ValueConstructor q t
-        CEV.NewtypeConstructor _ _ t  -> makeValueSymbol ValueConstructor q t
-        CEV.Value _ _ _ t             -> makeValueSymbol ValueFunction q t
-        CEV.Label _ _ t               -> makeValueSymbol ValueFunction q t
+    toSymbols (q, vinfo)
+        | CI.isQualified q' = pure <$> case vinfo of
+            CEV.DataConstructor _ _ ls t  -> (\s -> s { sConstructors = ppToText <$> ls })
+                                        <$> makeValueSymbol ValueConstructor q' t
+            CEV.NewtypeConstructor _ _ t  -> makeValueSymbol ValueConstructor q' t
+            CEV.Value _ _ _ t             -> makeValueSymbol ValueFunction q' t
+            CEV.Label _ _ t               -> makeValueSymbol ValueFunction q' t
+        | otherwise         = return []
+        where q' = qualifyWithModuleFrom vinfo q
 
 instance ToSymbols (CI.QualIdent, CETC.TypeInfo) where
-    toSymbols (q, tinfo) = case tinfo of
-        CETC.DataType _ k _     -> pure <$> makeTypeSymbol TypeData q k
-        CETC.RenamingType _ k _ -> pure <$> makeTypeSymbol TypeNew q k
-        CETC.AliasType _ k _ _  -> pure <$> makeTypeSymbol TypeAlias q k
-        CETC.TypeClass _ k _    -> pure <$> makeTypeSymbol TypeClass q k
-        CETC.TypeVar _          -> return []
+    toSymbols (q, tinfo)
+        | CI.isQualified q' = case tinfo of
+            CETC.DataType _ k _     -> pure <$> makeTypeSymbol TypeData q' k
+            CETC.RenamingType _ k _ -> pure <$> makeTypeSymbol TypeNew q' k
+            CETC.AliasType _ k _ _  -> pure <$> makeTypeSymbol TypeAlias q' k
+            CETC.TypeClass _ k _    -> pure <$> makeTypeSymbol TypeClass q' k
+            CETC.TypeVar _          -> return []
+        | otherwise         = return []
+        where q' = qualifyWithModuleFrom tinfo q
 
 instance ToSymbols CI.ModuleIdent where
     toSymbols mid = do
@@ -49,6 +56,10 @@ instance ToSymbols CI.ModuleIdent where
                 , sIdent = fromMaybe "" $ lastSafe quals
                 , sLocation = loc
                 }
+
+qualifyWithModuleFrom :: CTE.Entity a => a -> CI.QualIdent -> CI.QualIdent
+qualifyWithModuleFrom (CTE.origName -> CI.qidModule -> Just mid) = CI.qualQualify mid
+qualifyWithModuleFrom _                                          = id
 
 makeValueSymbol :: SymbolKind -> CI.QualIdent -> CT.TypeScheme -> IO Symbol
 makeValueSymbol k q t = do

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -13,13 +13,15 @@ import Control.Monad.Trans.Maybe (runMaybeT)
 import Curry.LanguageServer.Index.Symbol (Symbol (..), SymbolKind (..))
 import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
 import Data.Default (Default (..))
+import qualified Data.Text as T
 
 class ToSymbol s where
     toSymbol :: s -> IO (Maybe Symbol)
     
 instance ToSymbol CEV.ValueInfo where
     toSymbol vinfo = Just <$> case vinfo of
-        CEV.DataConstructor q _ _ t   -> makeValueSymbol ValueConstructor q t
+        CEV.DataConstructor q _ ls t  -> (\s -> s { sConstructors = ppToText <$> ls })
+                                     <$> makeValueSymbol ValueConstructor q t
         CEV.NewtypeConstructor q _ t  -> makeValueSymbol ValueConstructor q t
         CEV.Value q _ _ t             -> makeValueSymbol ValueFunction q t
         CEV.Label q _ t               -> makeValueSymbol ValueFunction q t

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -1,0 +1,55 @@
+module Curry.LanguageServer.Index.Convert (
+    ToSymbol (..)
+) where
+
+-- Curry Compiler Libraries + Dependencies
+import qualified Curry.Base.Ident as CI
+import qualified Base.Types as CT
+import qualified Base.Kinds as CK
+import qualified Env.TypeConstructor as CETC
+import qualified Env.Value as CEV
+
+import Control.Monad.Trans.Maybe (runMaybeT)
+import Curry.LanguageServer.Index.Symbol (Symbol (..), SymbolKind (..))
+import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
+import Data.Default (Default (..))
+
+class ToSymbol s where
+    toSymbol :: s -> IO (Maybe Symbol)
+    
+instance ToSymbol CEV.ValueInfo where
+    toSymbol vinfo = Just <$> case vinfo of
+        CEV.DataConstructor q _ _ t   -> makeValueSymbol ValueConstructor q t
+        CEV.NewtypeConstructor q _ t  -> makeValueSymbol ValueConstructor q t
+        CEV.Value q _ _ t             -> makeValueSymbol ValueFunction q t
+        CEV.Label q _ t               -> makeValueSymbol ValueFunction q t
+
+instance ToSymbol CETC.TypeInfo where
+    toSymbol tinfo = case tinfo of
+        CETC.DataType q k _     -> Just <$> makeTypeSymbol TypeData q k
+        CETC.RenamingType q k _ -> Just <$> makeTypeSymbol TypeNew q k
+        CETC.AliasType q k _ _  -> Just <$> makeTypeSymbol TypeAlias q k
+        CETC.TypeClass q k _    -> Just <$> makeTypeSymbol TypeClass q k
+        CETC.TypeVar _          -> return Nothing
+
+makeValueSymbol :: SymbolKind -> CI.QualIdent -> CT.TypeScheme -> IO Symbol
+makeValueSymbol k q t = do
+    loc <- runMaybeT $ currySpanInfo2Location q
+    return def
+        { sKind = k
+        , sQualIdent = ppToText q
+        , sPrintedType = Just $ ppToText t
+        , sArrowArity = Just $ CT.arrowArity $ CT.rawType t
+        , sLocation = loc
+        }
+
+makeTypeSymbol :: SymbolKind -> CI.QualIdent -> CK.Kind -> IO Symbol
+makeTypeSymbol k q k' = do
+    loc <- runMaybeT $ currySpanInfo2Location q
+    return def
+        { sKind = k
+        , sQualIdent = ppToText q
+        , sPrintedType = Just $ ppToText k'
+        , sArrowArity = Just $ CK.kindArity k'
+        , sLocation = loc
+        }

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -13,7 +13,6 @@ import Control.Monad.Trans.Maybe (runMaybeT)
 import Curry.LanguageServer.Index.Symbol (Symbol (..), SymbolKind (..))
 import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
 import Data.Default (Default (..))
-import qualified Data.Text as T
 
 class ToSymbol s where
     toSymbol :: s -> IO (Maybe Symbol)
@@ -33,6 +32,16 @@ instance ToSymbol CETC.TypeInfo where
         CETC.AliasType q k _ _  -> Just <$> makeTypeSymbol TypeAlias q k
         CETC.TypeClass q k _    -> Just <$> makeTypeSymbol TypeClass q k
         CETC.TypeVar _          -> return Nothing
+
+instance ToSymbol CI.ModuleIdent where
+    toSymbol mid = do
+        loc <- runMaybeT $ currySpanInfo2Location mid
+        return $ Just def
+            { sKind = Module
+            , sQualIdent = ppToText mid
+            , sIdent = ppToText mid
+            , sLocation = loc
+            }
 
 makeValueSymbol :: SymbolKind -> CI.QualIdent -> CT.TypeScheme -> IO Symbol
 makeValueSymbol k q t = do

--- a/src/Curry/LanguageServer/Index/Lookup.hs
+++ b/src/Curry/LanguageServer/Index/Lookup.hs
@@ -1,5 +1,5 @@
 -- | (Value) environments and position lookup in the AST.
-module Curry.LanguageServer.Utils.Lookup (
+module Curry.LanguageServer.Index.Lookup (
     findQualIdentAtPos,
     findTypeAtPos
 ) where

--- a/src/Curry/LanguageServer/Index/Lookup.hs
+++ b/src/Curry/LanguageServer/Index/Lookup.hs
@@ -1,15 +1,21 @@
 -- | (Value) environments and position lookup in the AST.
 module Curry.LanguageServer.Index.Lookup (
     findQualIdentAtPos,
-    findTypeAtPos
+    resolveQualIdentAtPos,
+    findTypeAtPos,
+    resolveInStore
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
+import qualified Curry.Syntax as CS
 import qualified Base.Types as CT
 
 import Control.Applicative
+import qualified Curry.LanguageServer.Index.Store as I
+import qualified Curry.LanguageServer.Index.Symbol as I
+import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
 import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Syntax
 import qualified Language.LSP.Types as J
@@ -20,6 +26,24 @@ findQualIdentAtPos ast pos = qualIdent <|> exprIdent <|> basicIdent
     where qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
           exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
           basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
+
+-- | Resolves the qualified identifier at the given position.
+resolveQualIdentAtPos :: I.IndexStore -> ModuleAST -> J.Position -> Maybe ([I.Symbol], J.Range)
+resolveQualIdentAtPos store ast@(CS.Module _ _ _ mid _ imps _) pos = do
+    (qid, spi) <- findQualIdentAtPos ast pos
+    range <- currySpanInfo2Range spi
+    let symbols = do -- TODO: Deal with aliases
+                     qid' <- qid : (flip CI.qualQualify qid <$> ([mid, CI.mkMIdent ["Prelude"]]
+                                                              ++ [mid' | CS.ImportDecl _ mid' _ _ _ <- imps]))
+                     resolveInStore store qid'
+    return (symbols, range)
+
+resolveInStore :: I.IndexStore -> CI.QualIdent -> [I.Symbol]
+resolveInStore store qid = symbols'
+    where symbols = I.storedSymbolsByQualIdent qid store
+          symbols' | any I.sIsFromCurrySource symbols = filter I.sIsFromCurrySource symbols
+                   | otherwise                        = symbols
+
 
 -- | Finds the type at the given position.
 findTypeAtPos :: ModuleAST -> J.Position -> Maybe (TypedSpanInfo CT.PredType)

--- a/src/Curry/LanguageServer/Index/Lookup.hs
+++ b/src/Curry/LanguageServer/Index/Lookup.hs
@@ -18,6 +18,7 @@ import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
 import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Syntax
+import Curry.LanguageServer.Utils.Sema
 import qualified Language.LSP.Types as J
 
 -- | Finds identifier and (occurrence) span info at a given position.

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -1,32 +1,19 @@
--- | (Value) environments and position lookup in the AST.
-module Curry.LanguageServer.Index.Lookup (
-    findQualIdentAtPos,
+-- | Lookup and resolution with the index.
+module Curry.LanguageServer.Index.Resolve (
     resolveQualIdentAtPos,
-    findTypeAtPos,
     resolveInStore
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
-import qualified Curry.Base.SpanInfo as CSPI
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
 
-import Control.Applicative
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
-import Curry.LanguageServer.Utils.General
-import Curry.LanguageServer.Utils.Syntax
-import Curry.LanguageServer.Utils.Sema
+import Curry.LanguageServer.Utils.Syntax (ModuleAST)
+import Curry.LanguageServer.Utils.Lookup (findQualIdentAtPos)
 import qualified Language.LSP.Types as J
-
--- | Finds identifier and (occurrence) span info at a given position.
-findQualIdentAtPos :: ModuleAST -> J.Position -> Maybe (CI.QualIdent, CSPI.SpanInfo)
-findQualIdentAtPos ast pos = qualIdent <|> exprIdent <|> basicIdent
-    where qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
-          exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
-          basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
 
 -- | Resolves the qualified identifier at the given position.
 resolveQualIdentAtPos :: I.IndexStore -> ModuleAST -> J.Position -> Maybe ([I.Symbol], J.Range)
@@ -46,9 +33,3 @@ resolveInStore store qid = symbols'
                    | otherwise                        = symbols
 
 
--- | Finds the type at the given position.
-findTypeAtPos :: ModuleAST -> J.Position -> Maybe (TypedSpanInfo CT.PredType)
-findTypeAtPos ast pos = elementAt pos $ typedSpanInfos ast
-
-withSpanInfo :: CSPI.HasSpanInfo a => a -> (a, CSPI.SpanInfo)
-withSpanInfo x = (x, CSPI.getSpanInfo x)

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -38,7 +38,7 @@ import Curry.LanguageServer.CPM.Deps (invokeCPMDeps)
 import Curry.LanguageServer.CPM.Monad (runCPMM)
 import qualified Curry.LanguageServer.Config as CFG
 import Curry.LanguageServer.Index.Symbol
-import Curry.LanguageServer.Utils.Conversions
+import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Syntax (ModuleAST)
 import Curry.LanguageServer.Utils.Uri

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -257,8 +257,8 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
         modify $ \s -> s { idxModules = modifyEntry updateEntry uri' $ idxModules s }
 
         -- Update symbol store
-        valueSymbols <- liftIO $ join <$> mapM (toSymbols . snd) (CT.allBindings $ CE.valueEnv env)
-        typeSymbols  <- liftIO $ join <$> mapM (toSymbols . snd) (CT.allBindings $ CE.tyConsEnv env)
+        valueSymbols <- liftIO $ join <$> mapM toSymbols (CT.allBindings $ CE.valueEnv env)
+        typeSymbols  <- liftIO $ join <$> mapM toSymbols (CT.allBindings $ CE.tyConsEnv env)
         modSymbols   <- liftIO $ join <$> mapM toSymbols (nubOrdOn ppToText $ mapMaybe (CI.qidModule . fst) $ CT.allImports (CE.valueEnv env))
 
         let symbolDelta = (\s -> (TE.encodeUtf8 $ sIdent s, [s])) <$> (valueSymbols ++ typeSymbols ++ modSymbols)

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -13,6 +13,7 @@ module Curry.LanguageServer.Index.Store (
     storedSymbolsByIdent,
     storedSymbolsWithPrefix,
     storedSymbolsByQualIdent,
+    storedModuleSymbolsWithPrefix,
     addWorkspaceDir,
     recompileModule,
     getModuleCount,
@@ -130,6 +131,10 @@ storedSymbolsWithPrefix pre = join . TR.elems . TR.submap (TE.encodeUtf8 pre) . 
 storedSymbolsByQualIdent :: CI.QualIdent -> IndexStore -> [Symbol]
 storedSymbolsByQualIdent q = filter ((== ppToText q) . sQualIdent) . storedSymbolsByIdent name
     where name = T.pack $ CI.idName $ CI.qidIdent q
+
+-- | Fetches stored module symbols starting with the given prefix.
+storedModuleSymbolsWithPrefix :: T.Text -> IndexStore -> [Symbol]
+storedModuleSymbolsWithPrefix pre = join . TR.elems . TR.submap (TE.encodeUtf8 pre) . idxModuleSymbols
 
 -- | Compiles the given directory recursively and stores its entries.
 addWorkspaceDir :: (MonadState IndexStore m, MonadIO m) => CFG.Config -> C.FileLoader -> FilePath -> m ()

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -4,7 +4,6 @@
 module Curry.LanguageServer.Index.Store (
     ModuleStoreEntry (..),
     IndexStore (..),
-    emptyStore,
     storedModuleCount,
     storedSymbolCount,
     storedModule,
@@ -90,9 +89,8 @@ instance Default ModuleStoreEntry where
                            , mseImportPaths = []
                            }
 
--- | Fetches an empty index store.
-emptyStore :: IndexStore
-emptyStore = IndexStore { idxModules = M.empty, idxSymbols = TR.empty, idxModuleSymbols = TR.empty }
+instance Default IndexStore where
+    def = IndexStore { idxModules = M.empty, idxSymbols = TR.empty, idxModuleSymbols = TR.empty }
 
 -- | Fetches the number of stored modules.
 storedModuleCount :: IndexStore -> Int

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -10,6 +10,7 @@ module Curry.LanguageServer.Index.Store (
     storedModule,
     storedModuleByIdent,
     storedModules,
+    storedSymbols,
     storedSymbolsByIdent,
     storedSymbolsWithPrefix,
     storedSymbolsByQualIdent,
@@ -111,6 +112,10 @@ storedModuleByIdent mident store = flip storedModule store <$> uri
 -- | Fetches the entries in the store as a list.
 storedModules :: IndexStore -> [(J.NormalizedUri, ModuleStoreEntry)]
 storedModules = M.toList . idxModules
+
+-- | Fetches all symbols.
+storedSymbols :: IndexStore -> [Symbol]
+storedSymbols = join . TR.toListBy (const id) . idxSymbols
 
 -- | Fetches the given (unqualified) symbol names in the store.
 storedSymbolsByIdent :: T.Text -> IndexStore -> [Symbol]

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Curry.LanguageServer.IndexStore (
+module Curry.LanguageServer.Index.Store (
     ModuleStoreEntry (..),
     SymbolStoreEntry (..),
     IndexStore (..),
@@ -62,12 +62,13 @@ import System.Process (readProcessWithExitCode)
 -- | An index store entry containing the parsed AST, the compilation environment
 -- and diagnostic messages.
 data ModuleStoreEntry = ModuleStoreEntry { mseModuleAST :: Maybe ModuleAST
-                                         , mseCompilerEnv :: Maybe CE.CompilerEnv
                                          , mseErrorMessages :: [CM.Message]
                                          , mseWarningMessages :: [CM.Message]
                                          , mseWorkspaceDir :: Maybe FilePath
                                          , mseImportPaths :: [FilePath]
                                          }
+
+
 
 -- | An index store entry containing a symbol.
 data SymbolStoreEntry = SymbolStoreEntry { sseSymbol :: J.SymbolInformation
@@ -84,7 +85,6 @@ data IndexStore = IndexStore { idxModules :: M.Map J.NormalizedUri ModuleStoreEn
 
 instance Default ModuleStoreEntry where
     def = ModuleStoreEntry { mseModuleAST = Nothing
-                           , mseCompilerEnv = Nothing
                            , mseWarningMessages = []
                            , mseErrorMessages = []
                            , mseWorkspaceDir = Nothing
@@ -253,7 +253,7 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
                 { mseWarningMessages = M.findWithDefault [] (Just uri') warns
                 , mseErrorMessages = M.findWithDefault [] (Just uri') errors
                 , mseModuleAST = Just ast
-                , mseCompilerEnv = Just env
+                -- , mseCompilerEnv = Just env
                 }
         modify $ \s -> s { idxModules = modifyEntry updateEntry uri' $ idxModules s }
 

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -10,7 +10,7 @@ module Curry.LanguageServer.Index.Store (
     storedModule,
     storedModuleByIdent,
     storedModules,
-    storedSymbols,
+    storedSymbolsByIdent,
     storedSymbolsWithPrefix,
     storedSymbolsByQualIdent,
     addWorkspaceDir,
@@ -113,8 +113,8 @@ storedModules :: IndexStore -> [(J.NormalizedUri, ModuleStoreEntry)]
 storedModules = M.toList . idxModules
 
 -- | Fetches the given (unqualified) symbol names in the store.
-storedSymbols :: T.Text -> IndexStore -> [Symbol]
-storedSymbols t = join . maybeToList . TR.lookup (TE.encodeUtf8 t) . idxSymbols
+storedSymbolsByIdent :: T.Text -> IndexStore -> [Symbol]
+storedSymbolsByIdent t = join . maybeToList . TR.lookup (TE.encodeUtf8 t) . idxSymbols
 
 -- | Fetches the list of symbols starting with the given prefix.
 storedSymbolsWithPrefix :: T.Text -> IndexStore -> [Symbol]
@@ -122,7 +122,7 @@ storedSymbolsWithPrefix pre = join . TR.elems . TR.submap (TE.encodeUtf8 pre) . 
 
 -- | Fetches stored symbols by qualified identifier.
 storedSymbolsByQualIdent :: CI.QualIdent -> IndexStore -> [Symbol]
-storedSymbolsByQualIdent q = filter ((== ppToText q) . sQualIdent) . storedSymbols name
+storedSymbolsByQualIdent q = filter ((== ppToText q) . sQualIdent) . storedSymbolsByIdent name
     where name = T.pack $ CI.idName $ CI.qidIdent q
 
 -- | Compiles the given directory recursively and stores its entries.

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -257,9 +257,9 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
         modify $ \s -> s { idxModules = modifyEntry updateEntry uri' $ idxModules s }
 
         -- Update symbol store
-        valueSymbols <- liftIO $ (maybeToList =<<) <$> mapM (toSymbol . snd) (CT.allBindings $ CE.valueEnv env)
-        typeSymbols  <- liftIO $ (maybeToList =<<) <$> mapM (toSymbol . snd) (CT.allBindings $ CE.tyConsEnv env)
-        modSymbols   <- liftIO $ (maybeToList =<<) <$> mapM toSymbol (nubOrdOn ppToText $ mapMaybe (CI.qidModule . fst) $ CT.allImports (CE.valueEnv env))
+        valueSymbols <- liftIO $ join <$> mapM (toSymbols . snd) (CT.allBindings $ CE.valueEnv env)
+        typeSymbols  <- liftIO $ join <$> mapM (toSymbols . snd) (CT.allBindings $ CE.tyConsEnv env)
+        modSymbols   <- liftIO $ join <$> mapM toSymbols (nubOrdOn ppToText $ mapMaybe (CI.qidModule . fst) $ CT.allImports (CE.valueEnv env))
 
         let symbolDelta = (\s -> (TE.encodeUtf8 $ sIdent s, [s])) <$> (valueSymbols ++ typeSymbols ++ modSymbols)
         liftIO $ debugM "cls.indexStore" $ "Inserting " ++ show (length symbolDelta) ++ " symbol(s)"

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -264,7 +264,7 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
         let symbolDelta = (\s -> (TE.encodeUtf8 $ sIdent s, [s])) <$> (valueSymbols ++ typeSymbols ++ modSymbols)
         liftIO $ debugM "cls.indexStore" $ "Inserting " ++ show (length symbolDelta) ++ " symbol(s)"
 
-        modify $ \s -> s { idxSymbols = insertAllIntoTrieWith (unionBy ((==) `on` sQualIdent)) symbolDelta $ idxSymbols s }
+        modify $ \s -> s { idxSymbols = insertAllIntoTrieWith (unionBy ((==) `on` (\s' -> (sQualIdent s', sIsFromCurrySource s')))) symbolDelta $ idxSymbols s }
     
     -- Update store with messages from files that were not successfully compiled
 

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -4,6 +4,7 @@ module Curry.LanguageServer.Index.Symbol (
 ) where
 
 import qualified Data.Text as T
+import qualified Language.LSP.Types as J
 
 -- | The 'kind' of the symbol in the LSP sense.
 data SymbolKind = Value | Module | TypeData | TypeNew | TypeClass | TypeAlias | TypeVar
@@ -11,7 +12,8 @@ data SymbolKind = Value | Module | TypeData | TypeNew | TypeClass | TypeAlias | 
 -- | A type or value. If it's a type, the 'printed type' will be the printed kind.
 data Symbol = Symbol
     { sKind :: SymbolKind
+    , sQualIdent :: T.Text
     , sPrintedType :: T.Text
     , sArrowArity :: Int
-    , sQualIdent :: T.Text
+    , sLocation :: J.Location
     }

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -1,0 +1,17 @@
+module Curry.LanguageServer.Index.Symbol (
+    SymbolKind (..),
+    Symbol (..)
+) where
+
+import qualified Data.Text as T
+
+-- | The 'kind' of the symbol in the LSP sense.
+data SymbolKind = Value | Module | TypeData | TypeNew | TypeClass | TypeAlias | TypeVar
+
+-- | A type or value. If it's a type, the 'printed type' will be the printed kind.
+data Symbol = Symbol
+    { sKind :: SymbolKind
+    , sPrintedType :: T.Text
+    , sArrowArity :: Int
+    , sQualIdent :: T.Text
+    }

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -2,13 +2,16 @@
 module Curry.LanguageServer.Index.Symbol (
     SymbolKind (..),
     Symbol (..),
-    sParentIdent
+    sParentIdent,
+    sIsFromCurrySource
 ) where
 
+import Control.Lens ((^.))
 import Data.Default (Default (..))
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
 
 -- | The 'kind' of the symbol in the LSP sense.
 data SymbolKind = ValueFunction
@@ -47,3 +50,6 @@ instance Default Symbol where
 
 sParentIdent :: Symbol -> T.Text
 sParentIdent s = fromMaybe "" $ T.stripSuffix ("." <> sIdent s) $ sQualIdent s
+
+sIsFromCurrySource :: Symbol -> Bool
+sIsFromCurrySource s = maybe False ((".curry" `T.isSuffixOf`) . J.getUri . (^. J.uri)) $ sLocation s

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -6,6 +6,7 @@ module Curry.LanguageServer.Index.Symbol (
 ) where
 
 import Data.Default (Default (..))
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Types as J
 
@@ -43,4 +44,4 @@ instance Default Symbol where
         }
 
 sParentIdent :: Symbol -> T.Text
-sParentIdent = T.intercalate "." . init . T.split (== '.') . sQualIdent
+sParentIdent s = fromMaybe "" $ T.stripSuffix ("." <> sIdent s) $ sQualIdent s

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -20,6 +20,7 @@ data SymbolKind = ValueFunction
                 | TypeAlias
                 | TypeVar
                 | Other
+    deriving (Show, Eq)
 
 -- | A type or value. If it's a type, the 'printed type' will be the printed kind.
 data Symbol = Symbol
@@ -31,6 +32,7 @@ data Symbol = Symbol
     , sConstructors :: [T.Text]
     , sLocation :: Maybe J.Location
     }
+    deriving (Show, Eq)
 
 instance Default Symbol where
     def = Symbol

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -31,6 +31,7 @@ data Symbol = Symbol
     , sQualIdent :: T.Text
     , sIdent :: T.Text
     , sPrintedType :: Maybe T.Text
+    , sPrintedArgumentTypes :: [T.Text]
     , sArrowArity :: Maybe Int
     , sConstructors :: [T.Text]
     , sLocation :: Maybe J.Location
@@ -43,6 +44,7 @@ instance Default Symbol where
         , sQualIdent = ""
         , sIdent = ""
         , sPrintedType = Nothing
+        , sPrintedArgumentTypes = []
         , sArrowArity = Nothing
         , sConstructors = []
         , sLocation = Nothing

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Index.Symbol (
     SymbolKind (..),
-    Symbol (..)
+    Symbol (..),
+    sParentIdent
 ) where
 
 import Data.Default (Default (..))
@@ -26,6 +27,7 @@ data Symbol = Symbol
     , sIdent :: T.Text
     , sPrintedType :: Maybe T.Text
     , sArrowArity :: Maybe Int
+    , sConstructors :: [T.Text]
     , sLocation :: Maybe J.Location
     }
 
@@ -36,5 +38,9 @@ instance Default Symbol where
         , sIdent = ""
         , sPrintedType = Nothing
         , sArrowArity = Nothing
+        , sConstructors = []
         , sLocation = Nothing
         }
+
+sParentIdent :: Symbol -> T.Text
+sParentIdent = T.intercalate "." . init . T.split (== '.') . sQualIdent

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -23,6 +23,7 @@ data SymbolKind = ValueFunction
 data Symbol = Symbol
     { sKind :: SymbolKind
     , sQualIdent :: T.Text
+    , sIdent :: T.Text
     , sPrintedType :: Maybe T.Text
     , sArrowArity :: Maybe Int
     , sLocation :: Maybe J.Location
@@ -32,6 +33,7 @@ instance Default Symbol where
     def = Symbol
         { sKind = Other
         , sQualIdent = ""
+        , sIdent = ""
         , sPrintedType = Nothing
         , sArrowArity = Nothing
         , sLocation = Nothing

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -1,19 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Index.Symbol (
     SymbolKind (..),
     Symbol (..)
 ) where
 
+import Data.Default (Default (..))
 import qualified Data.Text as T
 import qualified Language.LSP.Types as J
 
 -- | The 'kind' of the symbol in the LSP sense.
-data SymbolKind = Value | Module | TypeData | TypeNew | TypeClass | TypeAlias | TypeVar
+data SymbolKind = ValueFunction
+                | ValueConstructor
+                | Module
+                | TypeData
+                | TypeNew
+                | TypeClass
+                | TypeAlias
+                | TypeVar
+                | Other
 
 -- | A type or value. If it's a type, the 'printed type' will be the printed kind.
 data Symbol = Symbol
     { sKind :: SymbolKind
     , sQualIdent :: T.Text
-    , sPrintedType :: T.Text
-    , sArrowArity :: Int
-    , sLocation :: J.Location
+    , sPrintedType :: Maybe T.Text
+    , sArrowArity :: Maybe Int
+    , sLocation :: Maybe J.Location
     }
+
+instance Default Symbol where
+    def = Symbol
+        { sKind = Other
+        , sQualIdent = ""
+        , sPrintedType = Nothing
+        , sArrowArity = Nothing
+        , sLocation = Nothing
+        }

--- a/src/Curry/LanguageServer/Monad.hs
+++ b/src/Curry/LanguageServer/Monad.hs
@@ -27,7 +27,7 @@ data LSState = LSState { lssIndexStore :: I.IndexStore
                        }
 
 instance Default LSState where
-  def = LSState { lssIndexStore = I.emptyStore, lssDebouncers = M.empty }
+  def = LSState { lssIndexStore = def, lssDebouncers = M.empty }
 
 newLSStateVar :: IO (MVar LSState)
 newLSStateVar = newMVar def

--- a/src/Curry/LanguageServer/Monad.hs
+++ b/src/Curry/LanguageServer/Monad.hs
@@ -10,7 +10,7 @@ module Curry.LanguageServer.Monad (
 ) where
 
 import qualified Curry.LanguageServer.Config as CFG
-import qualified Curry.LanguageServer.IndexStore as I
+import qualified Curry.LanguageServer.Index.Store as I
 import Control.Concurrent.MVar (MVar, newMVar, readMVar, putMVar, modifyMVar)
 import Control.Monad.Reader (ReaderT, runReaderT, ask)
 import Control.Monad.State.Class (MonadState(..))

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -19,6 +19,7 @@ module Curry.LanguageServer.Utils.Convert (
     setCurryPosUri,
     setCurrySpanUri,
     setCurrySpanInfoUri,
+    ppToString,
     ppToText,
     ppTypeSchemeToText,
     ppPredTypeToText,
@@ -154,8 +155,11 @@ setCurrySpanInfoUri uri x@(CSPI.getSpanInfo -> spi@CSPI.SpanInfo {..}) = do
     return $ CSPI.setSpanInfo spi { CSPI.srcSpan = spn } x
 setCurrySpanInfoUri _ x = Just x
 
+ppToString :: CPP.Pretty p => p -> String
+ppToString = PP.render . CPP.pPrint
+
 ppToText :: CPP.Pretty p => p -> T.Text
-ppToText = T.pack . PP.render . CPP.pPrint
+ppToText = T.pack . ppToString
 
 ppTypeSchemeToText :: CI.ModuleIdent -> CT.TypeScheme -> T.Text
 ppTypeSchemeToText mid = T.pack . PP.render . CCT.ppTypeScheme mid

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -1,6 +1,6 @@
--- | Conversions between Curry Compiler and language server structures
+-- | Convert between Curry Compiler and language server structures
 {-# LANGUAGE RecordWildCards, ViewPatterns, OverloadedStrings, FlexibleInstances, UndecidableInstances #-}
-module Curry.LanguageServer.Utils.Conversions (
+module Curry.LanguageServer.Utils.Convert (
     curryMsg2Diagnostic,
     curryPos2Pos,
     curryPos2Uri,

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings, FunctionalDependencies, FlexibleInstances #-}
 -- | General utilities.
 module Curry.LanguageServer.Utils.General (
     lastSafe,
@@ -178,11 +178,8 @@ nothingIfNull xs = Just xs
 replaceString :: String -> String -> String -> String
 replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
 
-class Insertable m a where
+class Insertable m a | m -> a where
     insert :: a -> m -> m
-
-instance Insertable a a where
-    insert = const
 
 instance Insertable (Maybe a) a where
     insert = const . Just

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -203,7 +203,7 @@ instance Insertable (TR.Trie a) (B.ByteString, a) where
     insert = uncurry TR.insert
 
 -- | A map that 'pins' a key to a value once inserted.
-newtype ConstMap k v = ConstMap (M.Map k v)
+newtype ConstMap k v = ConstMap { ctmMap :: M.Map k v }
 
 instance Functor (ConstMap k) where
     fmap f (ConstMap m) = ConstMap $ fmap f m

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -34,10 +34,12 @@ import Control.Monad.Trans.Maybe
 import qualified Data.ByteString as B
 import Data.Bifunctor (first, second)
 import Data.Char (isSpace)
+import qualified Data.List as L
 import Data.Foldable (foldrM)
 import qualified Data.Text as T
 import qualified Data.Trie as TR
 import qualified Data.Map as M
+import qualified Data.Set as S
 import qualified Language.LSP.Types as J
 import System.FilePath
 import System.Directory
@@ -179,8 +181,20 @@ replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
 class Insertable m a where
     insert :: a -> m -> m
 
+instance Insertable a a where
+    insert = const
+
+instance Insertable (Maybe a) a where
+    insert = const . Just
+
+instance Ord a => Insertable [a] a where
+    insert = L.insert
+
 instance Ord k => Insertable (M.Map k v) (k, v) where
     insert = uncurry M.insert
+
+instance Ord a => Insertable (S.Set a) a where
+    insert = S.insert
 
 instance Insertable (TR.Trie a) (B.ByteString, a) where
     insert = uncurry TR.insert

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -20,7 +20,6 @@ module Curry.LanguageServer.Utils.General (
     nothingIfNull,
     replaceString,
     Insertable (..),
-    insertAll,
     insertIntoTrieWith,
     insertAllIntoTrieWith,
     groupIntoMapBy,
@@ -179,7 +178,13 @@ replaceString :: String -> String -> String -> String
 replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
 
 class Insertable m a | m -> a where
+    -- | Inserts a single entry.
     insert :: a -> m -> m
+    insert x = insertAll [x]
+
+    -- | Inserts multiple entries.
+    insertAll :: Foldable t => t a -> m -> m
+    insertAll = flip $ foldr insert
 
 instance Insertable (Maybe a) a where
     insert = const . Just
@@ -195,10 +200,6 @@ instance Ord a => Insertable (S.Set a) a where
 
 instance Insertable (TR.Trie a) (B.ByteString, a) where
     insert = uncurry TR.insert
-
--- | Inserts all entries into the given Insertable. Useful for maps.
-insertAll :: (Foldable t, Insertable m a) => t a -> m -> m
-insertAll = flip $ foldr insert
 
 -- | Inserts the given element into the trie using the combination function.
 -- The combination function takes the new value on the left and the old one on the right.

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -26,7 +26,8 @@ module Curry.LanguageServer.Utils.General (
     groupIntoMapBy,
     groupIntoMapByM,
     fst3, snd3, thd3,
-    tripleToPair
+    tripleToPair,
+    filterF
 ) where
 
 import Control.Monad (join)
@@ -255,3 +256,7 @@ thd3 (_, _, z) = z
 
 tripleToPair :: (a, b, c) -> (a, b)
 tripleToPair (x, y, _) = (x, y)
+
+-- | Filter over a foldable value. For [a], filterF = filter.
+filterF :: Foldable t => (a -> Bool) -> t a -> [a]
+filterF f = foldr (\x xs -> if f x then x : xs else xs) []

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -20,6 +20,7 @@ module Curry.LanguageServer.Utils.General (
     nothingIfNull,
     replaceString,
     Insertable (..),
+    ConstMap (..),
     insertIntoTrieWith,
     insertAllIntoTrieWith,
     groupIntoMapBy,
@@ -217,7 +218,9 @@ instance Ord k => Insertable (ConstMap k v) (k, v) where
     insert (k, v) (ConstMap m) = ConstMap $ M.insertWith (const id) k v m
 
 instance Ord k => Semigroup (ConstMap k v) where
-    ConstMap m <> ConstMap m' = ConstMap $ m <> m'
+    -- Note how ConstMap uses a 'flipped' (<>). This is analogous to how
+    -- the insertion combiner also corresponds to a 'flipped' const.
+    ConstMap m <> ConstMap m' = ConstMap $ M.union m' m
 
 instance Ord k => Monoid (ConstMap k v) where
     mempty = ConstMap M.empty

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -1,46 +1,35 @@
 -- | (Value) environments and position lookup in the AST.
 module Curry.LanguageServer.Utils.Lookup (
-    CanLookupValueInfo (..),
-    CanLookupTypeInfo (..),
-    LookupEnv,
     LM,
     runLM,
     findQualIdentAtPos,
     findTypeAtPos,
     getModuleIdentifier,
-    valueInfoType,
-    typeInfoKind
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
-import qualified Base.Kinds as CK
 import qualified Base.Types as CT
-import qualified CompilerEnv as CE
-import qualified Env.TypeConstructor as CETC
-import qualified Env.Value as CEV
 
 import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
 import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Syntax
-import Data.Maybe (listToMaybe)
 import qualified Language.LSP.Types as J
 
-type LookupEnv = (CE.CompilerEnv, ModuleAST)
-type LM a = MaybeT (ReaderT LookupEnv IO) a
+type LM a = MaybeT (ReaderT ModuleAST IO) a
 
 -- | Runs the lookup monad with the given environment and
 -- module identifier.
-runLM :: LM a -> CE.CompilerEnv -> ModuleAST -> IO (Maybe a)
-runLM lm = curry $ runReaderT $ runMaybeT lm
+runLM :: LM a -> ModuleAST -> IO (Maybe a)
+runLM = runReaderT . runMaybeT
 
 -- | Finds identifier and (occurrence) span info at a given position.
 findQualIdentAtPos :: J.Position -> LM (Maybe (CI.QualIdent, CSPI.SpanInfo))
 findQualIdentAtPos pos = do
-    (_, ast) <- lift ask
+    ast <- lift ask
     let qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
         exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
     return $ qualIdent <|> exprIdent
@@ -48,49 +37,12 @@ findQualIdentAtPos pos = do
 -- | Finds the type at the given position.
 findTypeAtPos :: J.Position -> LM (Maybe (TypedSpanInfo CT.PredType))
 findTypeAtPos pos = do
-    (_, ast) <- lift ask
+    ast <- lift ask
     let typedSpanInfo = elementAt pos $ typedSpanInfos ast
     return typedSpanInfo
 
 getModuleIdentifier :: LM CI.ModuleIdent
-getModuleIdentifier = moduleIdentifier . snd <$> lift ask
+getModuleIdentifier = moduleIdentifier <$> lift ask
 
 withSpanInfo :: CSPI.HasSpanInfo a => a -> (a, CSPI.SpanInfo)
 withSpanInfo x = (x, CSPI.getSpanInfo x)
-
--- | Fetches the type from a value info.
-valueInfoType :: CEV.ValueInfo -> CT.TypeScheme
-valueInfoType vinfo = case vinfo of
-    CEV.DataConstructor _ _ _ t  -> t
-    CEV.NewtypeConstructor _ _ t -> t
-    CEV.Value _ _ _ t            -> t
-    CEV.Label _ _ t              -> t
-
--- | Fetches the kind from a type info.
-typeInfoKind :: CETC.TypeInfo -> CK.Kind
-typeInfoKind tinfo = case tinfo of
-    CETC.DataType _ k _     -> k
-    CETC.RenamingType _ k _ -> k
-    CETC.AliasType _ k _ _  -> k
-    CETC.TypeClass _ k _    -> k
-    CETC.TypeVar k          -> k
-
-class CanLookupValueInfo i where
-    lookupValueInfo :: i -> LM (Maybe CEV.ValueInfo)
-
-instance CanLookupValueInfo CI.QualIdent where
-    lookupValueInfo ident = do
-        (env, ast) <- ask
-        let mident = moduleIdentifier ast
-            valueEnv = CE.valueEnv env
-        return $ listToMaybe $ CEV.qualLookupValueUnique mident ident valueEnv <|> CEV.qualLookupValue ident valueEnv
-
-class CanLookupTypeInfo i where
-    lookupTypeInfo :: i -> LM (Maybe CETC.TypeInfo)
-
-instance CanLookupTypeInfo CI.QualIdent where
-    lookupTypeInfo ident = do
-        (env, ast) <- ask
-        let mident = moduleIdentifier ast
-            tcEnv = CE.tyConsEnv env
-        return $ listToMaybe $ CETC.qualLookupTypeInfoUnique mident ident tcEnv <|> CETC.qualLookupTypeInfo ident tcEnv

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -1,0 +1,32 @@
+-- | Position lookup in the AST.
+module Curry.LanguageServer.Utils.Lookup (
+    findQualIdentAtPos,
+    findTypeAtPos
+) where
+
+-- Curry Compiler Libraries + Dependencies
+import qualified Curry.Base.Ident as CI
+import qualified Curry.Base.SpanInfo as CSPI
+import qualified Base.Types as CT
+
+import Control.Applicative
+import Curry.LanguageServer.Utils.General
+import Curry.LanguageServer.Utils.Syntax
+import Curry.LanguageServer.Utils.Sema
+import qualified Language.LSP.Types as J
+
+-- | Finds identifier and (occurrence) span info at a given position.
+findQualIdentAtPos :: ModuleAST -> J.Position -> Maybe (CI.QualIdent, CSPI.SpanInfo)
+findQualIdentAtPos ast pos = qualIdent <|> exprIdent <|> basicIdent
+    where qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
+          exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
+          basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
+
+
+
+-- | Finds the type at the given position.
+findTypeAtPos :: ModuleAST -> J.Position -> Maybe (TypedSpanInfo CT.PredType)
+findTypeAtPos ast pos = elementAt pos $ typedSpanInfos ast
+
+withSpanInfo :: CSPI.HasSpanInfo a => a -> (a, CSPI.SpanInfo)
+withSpanInfo x = (x, CSPI.getSpanInfo x)

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -1,5 +1,5 @@
 -- | (Value) environments and position lookup in the AST.
-module Curry.LanguageServer.Utils.Env (
+module Curry.LanguageServer.Utils.Lookup (
     CanLookupValueInfo (..),
     CanLookupTypeInfo (..),
     LookupEnv,

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -45,6 +45,10 @@ containsPos x pos = maybe False (rangeElem pos) $ currySpanInfo2Range x
 
 -- TODO: The current approach only works for scopes that are nested
 --       directly (i.e. parent SpanInfo contains child SpanInfo).
+--       This works for simple constructs, like function declarations,
+--       let-bindings, etc., but fails for do-sequences, list comprehensions,
+--       where-bindings etc.
+-- 
 --       Rewrite in a monadic way using NestEnvs since e.g.
 --       do-scopes are currently not handled correctly (i.e. the
 --       scope of a bound variable should be the variable and

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -1,10 +1,7 @@
 -- | (Value) environments and position lookup in the AST.
 module Curry.LanguageServer.Utils.Lookup (
-    LM,
-    runLM,
     findQualIdentAtPos,
-    findTypeAtPos,
-    getModuleIdentifier,
+    findTypeAtPos
 ) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -13,37 +10,20 @@ import qualified Curry.Base.SpanInfo as CSPI
 import qualified Base.Types as CT
 
 import Control.Applicative
-import Control.Monad.Reader
-import Control.Monad.Trans.Maybe
 import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Syntax
 import qualified Language.LSP.Types as J
 
-type LM a = MaybeT (ReaderT ModuleAST IO) a
-
--- | Runs the lookup monad with the given environment and
--- module identifier.
-runLM :: LM a -> ModuleAST -> IO (Maybe a)
-runLM = runReaderT . runMaybeT
-
 -- | Finds identifier and (occurrence) span info at a given position.
-findQualIdentAtPos :: J.Position -> LM (Maybe (CI.QualIdent, CSPI.SpanInfo))
-findQualIdentAtPos pos = do
-    ast <- lift ask
-    let qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
-        exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
-        basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
-    return $ qualIdent <|> exprIdent <|> basicIdent
+findQualIdentAtPos :: ModuleAST -> J.Position -> Maybe (CI.QualIdent, CSPI.SpanInfo)
+findQualIdentAtPos ast pos = qualIdent <|> exprIdent <|> basicIdent
+    where qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
+          exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
+          basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
 
 -- | Finds the type at the given position.
-findTypeAtPos :: J.Position -> LM (Maybe (TypedSpanInfo CT.PredType))
-findTypeAtPos pos = do
-    ast <- lift ask
-    let typedSpanInfo = elementAt pos $ typedSpanInfos ast
-    return typedSpanInfo
-
-getModuleIdentifier :: LM CI.ModuleIdent
-getModuleIdentifier = moduleIdentifier <$> lift ask
+findTypeAtPos :: ModuleAST -> J.Position -> Maybe (TypedSpanInfo CT.PredType)
+findTypeAtPos ast pos = elementAt pos $ typedSpanInfos ast
 
 withSpanInfo :: CSPI.HasSpanInfo a => a -> (a, CSPI.SpanInfo)
 withSpanInfo x = (x, CSPI.getSpanInfo x)

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -32,7 +32,8 @@ findQualIdentAtPos pos = do
     ast <- lift ask
     let qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
         exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
-    return $ qualIdent <|> exprIdent
+        basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
+    return $ qualIdent <|> exprIdent <|> basicIdent
 
 -- | Finds the type at the given position.
 findTypeAtPos :: J.Position -> LM (Maybe (TypedSpanInfo CT.PredType))

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -43,6 +43,12 @@ withName i = (ppToText $ CI.unRenameIdent i, i)
 containsPos :: CSPI.HasSpanInfo a => a -> J.Position -> Bool
 containsPos x pos = maybe False (rangeElem pos) $ currySpanInfo2Range x
 
+-- TODO: Rewrite in a monadic way using NestEnvs since e.g.
+--       do-scopes are currently not handled correctly (i.e. the
+--       scope of a bound variable should be the variable and
+--       all statements below, not just the bind itself).
+-- TODO: Attach (printed) type information for use by completions.
+
 class HasIdentifiersInScope a where
     -- | Finds all accessible identifiers at the given position, using the innermost shadowed one.
     identifiersInScope :: J.Position -> a -> ConstMap T.Text CI.Ident

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -1,18 +1,24 @@
+{-# LANGUAGE FlexibleInstances #-}
 -- | Position lookup in the AST.
 module Curry.LanguageServer.Utils.Lookup (
     findQualIdentAtPos,
-    findTypeAtPos
+    findTypeAtPos,
+    HasIdentifiersInScope (..)
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
+import qualified Curry.Syntax as CS
 import qualified Base.Types as CT
 
 import Control.Applicative
-import Curry.LanguageServer.Utils.General
+import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range, ppToText)
+import Curry.LanguageServer.Utils.General (rangeElem, Insertable (..), ConstMap (..), joinFst, (<.$>))
 import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Sema
+import Data.Foldable (fold)
+import qualified Data.Text as T
 import qualified Language.LSP.Types as J
 
 -- | Finds identifier and (occurrence) span info at a given position.
@@ -30,3 +36,104 @@ findTypeAtPos ast pos = elementAt pos $ typedSpanInfos ast
 
 withSpanInfo :: CSPI.HasSpanInfo a => a -> (a, CSPI.SpanInfo)
 withSpanInfo x = (x, CSPI.getSpanInfo x)
+
+withName :: CI.Ident -> (T.Text, CI.Ident)
+withName i = (ppToText i, i)
+
+containsPos :: CSPI.HasSpanInfo a => a -> J.Position -> Bool
+containsPos x pos = maybe False (rangeElem pos) $ currySpanInfo2Range x
+
+class HasIdentifiersInScope a where
+    -- | Finds all accessible identifiers at the given position, using the innermost shadowed one.
+    identifiersInScope :: J.Position -> a -> ConstMap T.Text CI.Ident
+
+instance HasIdentifiersInScope (CS.Module a) where
+    identifiersInScope pos (CS.Module _ _ _ _ _ _ decls) = identifiersInScope pos decls
+
+instance HasIdentifiersInScope (CS.Decl a) where
+    identifiersInScope pos decl
+        | decl `containsPos` pos = case decl of
+            CS.DataDecl _ _ vs _ _    -> insertAll (withName <$> vs) mempty
+            CS.NewtypeDecl _ _ vs _ _ -> insertAll (withName <$> vs) mempty
+            CS.TypeDecl _ _ vs _      -> insertAll (withName <$> vs) mempty
+            CS.FunctionDecl _ _ i eqs -> insert (withName i) $ identifiersInScope pos eqs
+            CS.PatternDecl _ p rhs    -> insertAll (withName <$> identifiers p) $ identifiersInScope pos rhs
+            _                         -> mempty -- TODO: Class/instance decls
+        | otherwise              = mempty
+
+instance HasIdentifiersInScope (CS.Equation a) where
+    identifiersInScope pos eqn@(CS.Equation _ lhs rhs)
+        | eqn `containsPos` pos = insertAll (withName <$> identifiers lhs) $ identifiersInScope pos rhs
+        | otherwise             = mempty
+
+instance HasIdentifiersInScope (CS.Rhs a) where
+    identifiersInScope pos rhs
+        | rhs `containsPos` pos = case rhs of
+            CS.SimpleRhs _ _ e ds   -> identifiersInScope pos e <> identifiersInScope pos ds
+            CS.GuardedRhs _ _ cs ds -> identifiersInScope pos cs <> identifiersInScope pos ds
+        | otherwise             = mempty
+
+instance HasIdentifiersInScope (CS.CondExpr a) where
+    identifiersInScope pos c@(CS.CondExpr _ e1 e2)
+        | c `containsPos` pos = identifiersInScope pos e1 <> identifiersInScope pos e2
+        | otherwise           = mempty
+
+instance HasIdentifiersInScope (CS.Expression a) where
+    identifiersInScope pos expr
+        | expr `containsPos` pos = case expr of
+            CS.Paren _ e                 -> identifiersInScope pos e
+            CS.Typed _ e _               -> identifiersInScope pos e
+            CS.Record _ _ _ fs           -> identifiersInScope pos fs
+            CS.RecordUpdate _ e fs       -> identifiersInScope pos e <> identifiersInScope pos fs
+            CS.Tuple _ es                -> identifiersInScope pos es
+            CS.List _ _ es               -> identifiersInScope pos es
+            CS.ListCompr _ e stmts       -> identifiersInScope pos e <> identifiersInScope pos stmts
+            CS.EnumFrom _ e              -> identifiersInScope pos e
+            CS.EnumFromThen _ e1 e2      -> identifiersInScope pos e1 <> identifiersInScope pos e2
+            CS.EnumFromTo _ e1 e2        -> identifiersInScope pos e1 <> identifiersInScope pos e2
+            CS.EnumFromThenTo _ e1 e2 e3 -> identifiersInScope pos e1 <> identifiersInScope pos e2 <> identifiersInScope pos e3
+            CS.UnaryMinus _ e            -> identifiersInScope pos e
+            CS.Apply _ e1 e2             -> identifiersInScope pos e1 <> identifiersInScope pos e2
+            CS.InfixApply _ e1 _ e2      -> identifiersInScope pos e1 <> identifiersInScope pos e2
+            CS.LeftSection _ e _         -> identifiersInScope pos e
+            CS.RightSection _ _ e        -> identifiersInScope pos e
+            CS.Lambda _ ps e             -> insertAll (withName <$> identifiers ps) $ identifiersInScope pos e
+            CS.Let _ _ ds e              -> identifiersInScope pos ds <> identifiersInScope pos e
+            CS.Do _ _ stmts e            -> identifiersInScope pos stmts <> identifiersInScope pos e
+            CS.IfThenElse _ e1 e2 e3     -> identifiersInScope pos e1 <> identifiersInScope pos e2 <> identifiersInScope pos e3
+            CS.Case _ _ _ e as           -> identifiersInScope pos e <> identifiersInScope pos as
+            _                            -> mempty
+        | otherwise              = mempty
+
+instance HasIdentifiersInScope a => HasIdentifiersInScope (CS.Field a) where
+    identifiersInScope pos f@(CS.Field _ _ e)
+        | f `containsPos` pos = identifiersInScope pos e
+        | otherwise           = mempty
+
+instance HasIdentifiersInScope (CS.Statement a) where
+    identifiersInScope pos stmt
+        | stmt `containsPos` pos = case stmt of
+            CS.StmtExpr _ e    -> identifiersInScope pos e
+            CS.StmtDecl _ _ ds -> identifiersInScope pos ds
+            -- TODO: This exposes more variables than actually in scope, as bound
+            --       variables are not accessible from within the expression (as
+            --       opposed to e.g. let-bindings which allow recursion). However,
+            --       shadowing should still work properly, e.g.
+            --
+            --           e <- let e = 3 in show e
+            --                                  ^
+            --       ...should cause the rightmost e to be referring to the let-bound
+            --       e (rather than the statement-bound e).
+            CS.StmtBind _ p e  -> insertAll (withName <$> identifiers p) $ identifiersInScope pos e
+        | otherwise              = mempty
+
+instance HasIdentifiersInScope (CS.Alt a) where
+    identifiersInScope pos alt@(CS.Alt _ p rhs)
+        | alt `containsPos` pos = insertAll (withName <$> identifiers p) $ identifiersInScope pos rhs
+        | otherwise             = mempty
+
+instance {-# OVERLAPPABLE #-} (Foldable f, Functor f, HasIdentifiersInScope a) => HasIdentifiersInScope (f a) where
+    -- Later occurrences of variables in the Foldable are preferred
+    -- due to (<>) being 'flipped'/right-biased in ConstMap compared
+    -- to Data.Map's semigroup instance (which is left-biased).
+    identifiersInScope pos = fold . (identifiersInScope pos <$>)

--- a/src/Curry/LanguageServer/Utils/Sema.hs
+++ b/src/Curry/LanguageServer/Utils/Sema.hs
@@ -1,17 +1,146 @@
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, UndecidableInstances #-}
 -- | Utilities for extracting semantic information from the AST.
 module Curry.LanguageServer.Utils.Sema (
+    HasTypedSpanInfos (..),
+    TypedSpanInfo (..),
     untypedTopLevelDecls
 ) where
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
+import qualified Curry.Base.Position as CP
 import qualified Curry.Syntax as CS
+import qualified Base.Types as CT
 
+import Curry.LanguageServer.Utils.Convert (ppToText)
+import Data.Maybe (maybeToList, mapMaybe)
 import qualified Data.Set as S
+import qualified Data.Text as T
 
 -- | Finds top-level function declarations in the module without an explicit type signature.
 untypedTopLevelDecls :: CS.Module a -> [(CSPI.SpanInfo, CI.Ident, a)]
 untypedTopLevelDecls (CS.Module _ _ _ _ _ _ decls) = untypedDecls
     where typeSigIdents = S.fromList [i | CS.TypeSig _ is _ <- decls, i <- is]
           untypedDecls = [(spi, i, t) | CS.FunctionDecl spi t i _ <- decls, i `S.notMember` typeSigIdents]
+
+data TypedSpanInfo a = TypedSpanInfo T.Text a CSPI.SpanInfo
+    deriving (Show, Eq)
+
+class HasTypedSpanInfos e a where
+    typedSpanInfos :: e -> [TypedSpanInfo a]
+
+instance HasTypedSpanInfos (CS.Module a) a where
+    typedSpanInfos (CS.Module _ _ _ _ _ _ decls) = typedSpanInfos decls
+
+instance HasTypedSpanInfos (CS.Decl a) a where
+    typedSpanInfos decl = case decl of
+        CS.FunctionDecl _ t i es     -> TypedSpanInfo (ppToText i) t (CSPI.getSpanInfo i) : typedSpanInfos es
+        CS.ExternalDecl _ vs         -> typedSpanInfos vs
+        CS.PatternDecl _ p rhs       -> typedSpanInfos p ++ typedSpanInfos rhs
+        CS.FreeDecl _ vs             -> typedSpanInfos vs
+        CS.ClassDecl _ _ _ _ _ ds    -> typedSpanInfos ds
+        CS.InstanceDecl _ _ _ _ _ ds -> typedSpanInfos ds
+        _                            -> []
+
+instance HasTypedSpanInfos (CS.Equation a) a where
+    typedSpanInfos (CS.Equation _ lhs rhs) = typedSpanInfos lhs ++ typedSpanInfos rhs
+
+instance HasTypedSpanInfos (CS.Var a) a where
+    typedSpanInfos (CS.Var t i) = [TypedSpanInfo txt t $ CSPI.getSpanInfo i]
+        where txt = ppToText i
+
+instance HasTypedSpanInfos (CS.Pattern a) a where
+    typedSpanInfos pat = case pat of
+        CS.LiteralPattern spi t _         -> [TypedSpanInfo txt t spi]
+        CS.NegativePattern spi t _        -> [TypedSpanInfo txt t spi]
+        CS.VariablePattern spi t _        -> [TypedSpanInfo txt t spi]
+        CS.ConstructorPattern spi t _ ps  -> TypedSpanInfo txt t spi : typedSpanInfos ps
+        CS.InfixPattern spi t p1 _ p2     -> typedSpanInfos p1 ++ typedSpanInfos p2 ++ [TypedSpanInfo txt t spi]
+        CS.ParenPattern _ p               -> typedSpanInfos p
+        CS.RecordPattern spi t _ fs       -> TypedSpanInfo txt t spi : typedSpanInfos fs
+        CS.TuplePattern _ ps              -> typedSpanInfos ps
+        CS.ListPattern spi t ps           -> TypedSpanInfo txt t spi : typedSpanInfos ps
+        CS.AsPattern _ _ p                -> typedSpanInfos p
+        CS.LazyPattern _ p                -> typedSpanInfos p
+        CS.FunctionPattern spi t _ ps     -> TypedSpanInfo txt t spi : typedSpanInfos ps
+        CS.InfixFuncPattern spi t p1 _ p2 -> typedSpanInfos p1 ++ typedSpanInfos p2 ++ [TypedSpanInfo txt t spi]
+        where txt = ppToText pat
+
+instance HasTypedSpanInfos e a => HasTypedSpanInfos (CS.Field e) a where
+    typedSpanInfos (CS.Field _ _ e) = typedSpanInfos e
+
+instance HasTypedSpanInfos (CS.Lhs a) a where
+    typedSpanInfos lhs = case lhs of
+        CS.FunLhs _ _ ps   -> typedSpanInfos ps
+        CS.OpLhs _ p1 _ p2 -> typedSpanInfos p1 ++ typedSpanInfos p2
+        CS.ApLhs _ l ps    -> typedSpanInfos l ++ typedSpanInfos ps
+
+instance HasTypedSpanInfos (CS.Rhs a) a where
+    typedSpanInfos rhs = case rhs of
+        CS.SimpleRhs _ _ e ds   -> typedSpanInfos e ++ typedSpanInfos ds
+        CS.GuardedRhs _ _ es ds -> typedSpanInfos es ++ typedSpanInfos ds
+
+instance HasTypedSpanInfos (CS.CondExpr a) a where
+    typedSpanInfos (CS.CondExpr _ e1 e2) = typedSpanInfos e1 ++ typedSpanInfos e2
+
+instance HasTypedSpanInfos (CS.Expression a) a where
+    typedSpanInfos expr = case expr of
+        CS.Literal spi t _           -> [TypedSpanInfo txt t spi]
+        CS.Variable spi t _          -> [TypedSpanInfo txt t spi]
+        CS.Constructor spi t _       -> [TypedSpanInfo txt t spi]
+        CS.Paren _ e                 -> typedSpanInfos e
+        CS.Typed _ e _               -> typedSpanInfos e
+        CS.Record spi t _ fs         -> TypedSpanInfo txt t spi : typedSpanInfos fs
+        CS.RecordUpdate _ e fs       -> typedSpanInfos e ++ typedSpanInfos fs
+        CS.Tuple _ es                -> typedSpanInfos es
+        CS.List spi t es             -> TypedSpanInfo txt t spi : typedSpanInfos es
+        CS.ListCompr _ e stmts       -> typedSpanInfos e ++ typedSpanInfos stmts
+        CS.EnumFrom _ e              -> typedSpanInfos e
+        CS.EnumFromThen _ e1 e2      -> typedSpanInfos e1 ++ typedSpanInfos e2
+        CS.EnumFromTo _ e1 e2        -> typedSpanInfos e1 ++ typedSpanInfos e2
+        CS.EnumFromThenTo _ e1 e2 e3 -> typedSpanInfos e1 ++ typedSpanInfos e2 ++ typedSpanInfos e3
+        CS.UnaryMinus _ e            -> typedSpanInfos e
+        CS.Apply _ e1 e2             -> typedSpanInfos e1 ++ typedSpanInfos e2
+        CS.InfixApply _ e1 op e2     -> typedSpanInfos e1 ++ typedSpanInfos op ++ typedSpanInfos e2
+        CS.LeftSection _ e1 op       -> typedSpanInfos e1 ++ typedSpanInfos op
+        CS.RightSection _ op e2      -> typedSpanInfos op ++ typedSpanInfos e2
+        CS.Lambda _ ps e             -> typedSpanInfos ps ++ typedSpanInfos e
+        CS.Let _ _ ds e              -> typedSpanInfos ds ++ typedSpanInfos e
+        CS.Do _ _ stmts e            -> typedSpanInfos stmts ++ typedSpanInfos e
+        CS.IfThenElse _ e1 e2 e3     -> typedSpanInfos e1 ++ typedSpanInfos e2 ++ typedSpanInfos e3
+        CS.Case _ _ _ e as           -> typedSpanInfos e ++ typedSpanInfos as
+        where txt = ppToText expr
+
+instance HasTypedSpanInfos (CS.Alt a) a where
+    typedSpanInfos (CS.Alt _ p rhs) = typedSpanInfos p ++ typedSpanInfos rhs
+
+instance HasTypedSpanInfos (CS.InfixOp a) a where
+    typedSpanInfos op = case op of
+        CS.InfixOp t q     -> [TypedSpanInfo txt t $ CSPI.getSpanInfo q]
+        CS.InfixConstr t q -> [TypedSpanInfo txt t $ CSPI.getSpanInfo q]
+        where txt = ppToText op
+
+instance HasTypedSpanInfos (CS.Statement a) a where
+    typedSpanInfos stmt = case stmt of
+        CS.StmtExpr _ e    -> typedSpanInfos e
+        CS.StmtDecl _ _ ds -> typedSpanInfos ds
+        CS.StmtBind _ p e  -> typedSpanInfos p ++ typedSpanInfos e
+
+instance HasTypedSpanInfos e a => HasTypedSpanInfos [e] a where
+    typedSpanInfos = (typedSpanInfos =<<)
+
+instance HasTypedSpanInfos e a => HasTypedSpanInfos (Maybe e) a where
+    typedSpanInfos = typedSpanInfos . maybeToList
+
+instance HasTypedSpanInfos e (Maybe CT.PredType) => HasTypedSpanInfos e CT.PredType where
+    typedSpanInfos = mapMaybe extract . typedSpanInfos
+        where extract (TypedSpanInfo txt (Just t) spi) = Just $ TypedSpanInfo txt t spi
+              extract _                                = Nothing
+
+instance CP.HasPosition (TypedSpanInfo a) where
+    getPosition (TypedSpanInfo _ _ spi) = CP.getPosition spi
+
+instance CSPI.HasSpanInfo (TypedSpanInfo a) where
+    getSpanInfo (TypedSpanInfo _ _ spi) = spi
+    setSpanInfo spi (TypedSpanInfo txt t _) = TypedSpanInfo txt t spi

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -21,7 +21,7 @@ import qualified Curry.Base.Position as CP
 import qualified Base.Types as CT
 import qualified Curry.Syntax as CS
 
-import Curry.LanguageServer.Utils.Conversions
+import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.General
 import Data.Maybe (maybeToList, mapMaybe)
 import qualified Data.Text as T

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -23,11 +23,11 @@ import qualified Curry.Syntax as CS
 
 import Curry.LanguageServer.Utils.Conversions
 import Curry.LanguageServer.Utils.General
-import Data.Maybe (maybeToList)
+import Data.Maybe (maybeToList, mapMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Types as J
 
-type ModuleAST = CS.Module CT.PredType
+type ModuleAST = CS.Module (Maybe CT.PredType)
 
 -- | Fetches the element at the given position.
 elementAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> Maybe e
@@ -541,6 +541,11 @@ instance HasTypedSpanInfos e a => HasTypedSpanInfos [e] a where
 
 instance HasTypedSpanInfos e a => HasTypedSpanInfos (Maybe e) a where
     typedSpanInfos = typedSpanInfos . maybeToList
+
+instance HasTypedSpanInfos e (Maybe CT.PredType) => HasTypedSpanInfos e CT.PredType where
+    typedSpanInfos = mapMaybe extract . typedSpanInfos
+        where extract (TypedSpanInfo txt (Just t) spi) = Just $ TypedSpanInfo txt t spi
+              extract _                                = Nothing
 
 instance CP.HasPosition (TypedSpanInfo a) where
     getPosition (TypedSpanInfo _ _ spi) = CP.getPosition spi

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -290,8 +290,11 @@ instance HasIdentifiers (CS.Decl a) where
         CS.PatternDecl _ p rhs        -> identifiers p ++ identifiers rhs
         CS.FreeDecl _ vs              -> identifiers vs
         CS.DefaultDecl _ ts           -> identifiers ts
-        CS.ClassDecl _ _ _ i1 i2 ds   -> i1 : i2 : identifiers ds
-        CS.InstanceDecl _ _ _ _ _ ds  -> identifiers ds
+        CS.ClassDecl _ _ c i1 i2 ds   -> identifiers c ++ i1 : i2 : identifiers ds
+        CS.InstanceDecl _ _ c _ _ ds  -> identifiers c ++ identifiers ds
+
+instance HasIdentifiers CS.Constraint where
+    identifiers (CS.Constraint _ _ t) = identifiers t
 
 instance HasIdentifiers (CS.Equation a) where
     identifiers (CS.Equation _ lhs rhs) = identifiers lhs ++ identifiers rhs
@@ -390,7 +393,7 @@ instance HasIdentifiers CS.TypeExpr where
         _                    -> []
 
 instance HasIdentifiers CS.QualTypeExpr where
-    identifiers (CS.QualTypeExpr _ _ t) = identifiers t
+    identifiers (CS.QualTypeExpr _ c t) = identifiers c ++ identifiers t
 
 instance HasIdentifiers a => HasIdentifiers [a] where
     identifiers = (identifiers =<<)

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -7,8 +7,6 @@ module Curry.LanguageServer.Utils.Syntax (
     HasIdentifiers (..),
     HasQualIdentifier (..),
     HasIdentifier (..),
-    HasTypedSpanInfos (..),
-    TypedSpanInfo (..),
     ModuleAST,
     elementAt,
     moduleIdentifier
@@ -17,14 +15,12 @@ module Curry.LanguageServer.Utils.Syntax (
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
-import qualified Curry.Base.Position as CP
 import qualified Base.Types as CT
 import qualified Curry.Syntax as CS
 
 import Curry.LanguageServer.Utils.Convert
 import Curry.LanguageServer.Utils.General
-import Data.Maybe (maybeToList, mapMaybe)
-import qualified Data.Text as T
+import Data.Maybe (maybeToList)
 import qualified Language.LSP.Types as J
 
 type ModuleAST = CS.Module (Maybe CT.PredType)
@@ -432,124 +428,3 @@ instance HasIdentifier (CS.Decl a) where
         CS.FunctionDecl _ _ ident _   -> Just ident
         CS.ClassDecl _ _ _ ident _ _  -> Just ident
         _                             -> Nothing
-
-data TypedSpanInfo a = TypedSpanInfo T.Text a CSPI.SpanInfo
-    deriving (Show, Eq)
-
-class HasTypedSpanInfos e a where
-    typedSpanInfos :: e -> [TypedSpanInfo a]
-
-instance HasTypedSpanInfos (CS.Module a) a where
-    typedSpanInfos (CS.Module _ _ _ _ _ _ decls) = typedSpanInfos decls
-
-instance HasTypedSpanInfos (CS.Decl a) a where
-    typedSpanInfos decl = case decl of
-        CS.FunctionDecl _ t i es     -> TypedSpanInfo (ppToText i) t (CSPI.getSpanInfo i) : typedSpanInfos es
-        CS.ExternalDecl _ vs         -> typedSpanInfos vs
-        CS.PatternDecl _ p rhs       -> typedSpanInfos p ++ typedSpanInfos rhs
-        CS.FreeDecl _ vs             -> typedSpanInfos vs
-        CS.ClassDecl _ _ _ _ _ ds    -> typedSpanInfos ds
-        CS.InstanceDecl _ _ _ _ _ ds -> typedSpanInfos ds
-        _                            -> []
-
-instance HasTypedSpanInfos (CS.Equation a) a where
-    typedSpanInfos (CS.Equation _ lhs rhs) = typedSpanInfos lhs ++ typedSpanInfos rhs
-
-instance HasTypedSpanInfos (CS.Var a) a where
-    typedSpanInfos (CS.Var t i) = [TypedSpanInfo txt t $ CSPI.getSpanInfo i]
-        where txt = ppToText i
-
-instance HasTypedSpanInfos (CS.Pattern a) a where
-    typedSpanInfos pat = case pat of
-        CS.LiteralPattern spi t _         -> [TypedSpanInfo txt t spi]
-        CS.NegativePattern spi t _        -> [TypedSpanInfo txt t spi]
-        CS.VariablePattern spi t _        -> [TypedSpanInfo txt t spi]
-        CS.ConstructorPattern spi t _ ps  -> TypedSpanInfo txt t spi : typedSpanInfos ps
-        CS.InfixPattern spi t p1 _ p2     -> typedSpanInfos p1 ++ typedSpanInfos p2 ++ [TypedSpanInfo txt t spi]
-        CS.ParenPattern _ p               -> typedSpanInfos p
-        CS.RecordPattern spi t _ fs       -> TypedSpanInfo txt t spi : typedSpanInfos fs
-        CS.TuplePattern _ ps              -> typedSpanInfos ps
-        CS.ListPattern spi t ps           -> TypedSpanInfo txt t spi : typedSpanInfos ps
-        CS.AsPattern _ _ p                -> typedSpanInfos p
-        CS.LazyPattern _ p                -> typedSpanInfos p
-        CS.FunctionPattern spi t _ ps     -> TypedSpanInfo txt t spi : typedSpanInfos ps
-        CS.InfixFuncPattern spi t p1 _ p2 -> typedSpanInfos p1 ++ typedSpanInfos p2 ++ [TypedSpanInfo txt t spi]
-        where txt = ppToText pat
-
-instance HasTypedSpanInfos e a => HasTypedSpanInfos (CS.Field e) a where
-    typedSpanInfos (CS.Field _ _ e) = typedSpanInfos e
-
-instance HasTypedSpanInfos (CS.Lhs a) a where
-    typedSpanInfos lhs = case lhs of
-        CS.FunLhs _ _ ps   -> typedSpanInfos ps
-        CS.OpLhs _ p1 _ p2 -> typedSpanInfos p1 ++ typedSpanInfos p2
-        CS.ApLhs _ l ps    -> typedSpanInfos l ++ typedSpanInfos ps
-
-instance HasTypedSpanInfos (CS.Rhs a) a where
-    typedSpanInfos rhs = case rhs of
-        CS.SimpleRhs _ _ e ds   -> typedSpanInfos e ++ typedSpanInfos ds
-        CS.GuardedRhs _ _ es ds -> typedSpanInfos es ++ typedSpanInfos ds
-
-instance HasTypedSpanInfos (CS.CondExpr a) a where
-    typedSpanInfos (CS.CondExpr _ e1 e2) = typedSpanInfos e1 ++ typedSpanInfos e2
-
-instance HasTypedSpanInfos (CS.Expression a) a where
-    typedSpanInfos expr = case expr of
-        CS.Literal spi t _           -> [TypedSpanInfo txt t spi]
-        CS.Variable spi t _          -> [TypedSpanInfo txt t spi]
-        CS.Constructor spi t _       -> [TypedSpanInfo txt t spi]
-        CS.Paren _ e                 -> typedSpanInfos e
-        CS.Typed _ e _               -> typedSpanInfos e
-        CS.Record spi t _ fs         -> TypedSpanInfo txt t spi : typedSpanInfos fs
-        CS.RecordUpdate _ e fs       -> typedSpanInfos e ++ typedSpanInfos fs
-        CS.Tuple _ es                -> typedSpanInfos es
-        CS.List spi t es             -> TypedSpanInfo txt t spi : typedSpanInfos es
-        CS.ListCompr _ e stmts       -> typedSpanInfos e ++ typedSpanInfos stmts
-        CS.EnumFrom _ e              -> typedSpanInfos e
-        CS.EnumFromThen _ e1 e2      -> typedSpanInfos e1 ++ typedSpanInfos e2
-        CS.EnumFromTo _ e1 e2        -> typedSpanInfos e1 ++ typedSpanInfos e2
-        CS.EnumFromThenTo _ e1 e2 e3 -> typedSpanInfos e1 ++ typedSpanInfos e2 ++ typedSpanInfos e3
-        CS.UnaryMinus _ e            -> typedSpanInfos e
-        CS.Apply _ e1 e2             -> typedSpanInfos e1 ++ typedSpanInfos e2
-        CS.InfixApply _ e1 op e2     -> typedSpanInfos e1 ++ typedSpanInfos op ++ typedSpanInfos e2
-        CS.LeftSection _ e1 op       -> typedSpanInfos e1 ++ typedSpanInfos op
-        CS.RightSection _ op e2      -> typedSpanInfos op ++ typedSpanInfos e2
-        CS.Lambda _ ps e             -> typedSpanInfos ps ++ typedSpanInfos e
-        CS.Let _ _ ds e              -> typedSpanInfos ds ++ typedSpanInfos e
-        CS.Do _ _ stmts e            -> typedSpanInfos stmts ++ typedSpanInfos e
-        CS.IfThenElse _ e1 e2 e3     -> typedSpanInfos e1 ++ typedSpanInfos e2 ++ typedSpanInfos e3
-        CS.Case _ _ _ e as           -> typedSpanInfos e ++ typedSpanInfos as
-        where txt = ppToText expr
-
-instance HasTypedSpanInfos (CS.Alt a) a where
-    typedSpanInfos (CS.Alt _ p rhs) = typedSpanInfos p ++ typedSpanInfos rhs
-
-instance HasTypedSpanInfos (CS.InfixOp a) a where
-    typedSpanInfos op = case op of
-        CS.InfixOp t q     -> [TypedSpanInfo txt t $ CSPI.getSpanInfo q]
-        CS.InfixConstr t q -> [TypedSpanInfo txt t $ CSPI.getSpanInfo q]
-        where txt = ppToText op
-
-instance HasTypedSpanInfos (CS.Statement a) a where
-    typedSpanInfos stmt = case stmt of
-        CS.StmtExpr _ e    -> typedSpanInfos e
-        CS.StmtDecl _ _ ds -> typedSpanInfos ds
-        CS.StmtBind _ p e  -> typedSpanInfos p ++ typedSpanInfos e
-
-instance HasTypedSpanInfos e a => HasTypedSpanInfos [e] a where
-    typedSpanInfos = (typedSpanInfos =<<)
-
-instance HasTypedSpanInfos e a => HasTypedSpanInfos (Maybe e) a where
-    typedSpanInfos = typedSpanInfos . maybeToList
-
-instance HasTypedSpanInfos e (Maybe CT.PredType) => HasTypedSpanInfos e CT.PredType where
-    typedSpanInfos = mapMaybe extract . typedSpanInfos
-        where extract (TypedSpanInfo txt (Just t) spi) = Just $ TypedSpanInfo txt t spi
-              extract _                                = Nothing
-
-instance CP.HasPosition (TypedSpanInfo a) where
-    getPosition (TypedSpanInfo _ _ spi) = CP.getPosition spi
-
-instance CSPI.HasSpanInfo (TypedSpanInfo a) where
-    getSpanInfo (TypedSpanInfo _ _ spi) = spi
-    setSpanInfo spi (TypedSpanInfo txt t _) = TypedSpanInfo txt t spi


### PR DESCRIPTION
This branch replaces the previously stored compiler environments with memory-efficient, `Data.Text`-based symbols. This drastically decreases memory usage (3 GB -> 1 GB in large-ish codebases like KiCS2) and allows for more consistent and flexible features, including

* Completions for unimported symbols
* Better definition lookup
* ...

Additionally, some new features are added, including

* Parse-only compilations when one of the semantic checks errors
* Snippet completions for functions and type constructors