### PR TITLE
Implement Signature Help

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,6 +32,7 @@ runLanguageServer = do
         , S.options = S.defaultOptions
             { S.textDocumentSync = Just syncOptions
             , S.completionTriggerCharacters = Just ['.']
+            , S.signatureHelpTriggerCharacters = Just [' ']
             , S.executeCommandCommands = Just $ fst <$> commands
             , S.serverInfo = Just $ J.ServerInfo "Curry Language Server" Nothing
             }

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,7 +32,7 @@ runLanguageServer = do
         , S.options = S.defaultOptions
             { S.textDocumentSync = Just syncOptions
             , S.completionTriggerCharacters = Just ['.']
-            , S.signatureHelpTriggerCharacters = Just [' ']
+            , S.signatureHelpTriggerCharacters = Just [' ', '(', ')']
             , S.executeCommandCommands = Just $ fst <$> commands
             , S.serverInfo = Just $ J.ServerInfo "Curry Language Server" Nothing
             }

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -8,6 +8,7 @@ import Curry.LanguageServer.Handlers.Definition (definitionHandler)
 import Curry.LanguageServer.Handlers.DocumentSymbols (documentSymbolHandler)
 import Curry.LanguageServer.Handlers.Hover (hoverHandler)
 import Curry.LanguageServer.Handlers.Initialized (initializedHandler)
+import Curry.LanguageServer.Handlers.SignatureHelp (signatureHelpHandler)
 import Curry.LanguageServer.Handlers.TextDocument (didOpenHandler, didChangeHandler, didSaveHandler, didCloseHandler)
 import Curry.LanguageServer.Handlers.WorkspaceSymbols (workspaceSymbolHandler)
 import Curry.LanguageServer.Monad (LSM)
@@ -24,6 +25,7 @@ handlers = mconcat
     , workspaceSymbolHandler
     , codeActionHandler
     , codeLensHandler
+    , signatureHelpHandler
       -- Notification handlers
     , initializedHandler
     , didOpenHandler

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -23,9 +23,6 @@ import qualified Language.LSP.Types as J
 import qualified Language.LSP.Types.Lens as J
 import System.Log.Logger
 
-import Debug.Trace
-import Curry.LanguageServer.Utils.Convert (ppToString)
-
 signatureHelpHandler :: S.Handlers LSM
 signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req responder -> do
     liftIO $ debugM "cls.signatureHelp" "Processing signature help request"
@@ -47,11 +44,9 @@ fetchSignatureHelp store entry pos = runMaybeT $ do
     (sym, args) <- liftMaybe $ lastSafe $ do
         e@(CS.Apply _ _ _) <- exprs
         let base : args = appFull e
-        traceM $ "Signature help expr: " ++ ppToString e ++ ", base: " ++ ppToString base ++ ", args: " ++ show (ppToString <$> args)
-        traceM $ "Base is " ++ show base
         sym <- maybeToList $ lookupExpression store ast base
-        traceM $ "Found symbol " ++ show sym
         return (sym, args)
+    liftIO $ infoM "cls.signatureHelp" $ "Found symbol " ++ T.unpack (I.sQualIdent sym)
     let activeParam = maybe 0 fst $ find (elementContains pos . snd) (zip [0..] args)
         activeSig = 0
         labelStart = I.sQualIdent sym <> " :: "

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -14,7 +14,7 @@ import Curry.LanguageServer.Index.Resolve (resolveQualIdent)
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Monad
-import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe, snapToLastToken)
+import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe, snapToLastTokenStart)
 import Curry.LanguageServer.Utils.Sema (ModuleAST)
 import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
@@ -48,7 +48,7 @@ fetchSignatureHelp :: I.IndexStore -> I.ModuleStoreEntry -> VFS.VirtualFile -> J
 fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
     ast <- liftMaybe $ I.mseModuleAST entry
     let line = VFS.rangeLinesFromVfs vfile $ J.Range (J.Position l 0) (J.Position (l + 1) 0)
-        c'   = snapToLastToken (T.unpack line) c
+        c'   = snapToLastTokenStart (T.unpack line) c
         pos' = J.Position l c'
     (sym, args) <- liftMaybe $  findExpressionApplication store ast pos'
                             <|> findTypeApplication       store ast pos'

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Curry.LanguageServer.Handlers.SignatureHelp (signatureHelpHandler) where
+
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Maybe (runMaybeT)
+import qualified Curry.LanguageServer.Index.Store as I
+import Curry.LanguageServer.Monad
+import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
+import Data.Maybe (fromMaybe)
+import qualified Language.LSP.Server as S
+import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
+import System.Log.Logger
+
+signatureHelpHandler :: S.Handlers LSM
+signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req responder -> do
+    liftIO $ debugM "cls.signatureHelp" "Processing signature help request"
+    let J.SignatureHelpParams doc pos _ _ = req ^. J.params
+        uri = doc ^. J.uri
+    normUri <- liftIO $ normalizeUriWithPath uri
+    sigHelp <- runMaybeT $ do
+        entry <- I.getModule normUri
+        liftIO $ fetchSignatureHelp entry pos
+    responder $ Right $ fromMaybe emptyHelp sigHelp
+    where emptyHelp = J.SignatureHelp (J.List []) Nothing Nothing
+
+fetchSignatureHelp :: I.ModuleStoreEntry -> J.Position -> IO J.SignatureHelp
+fetchSignatureHelp entry pos = do
+    sig <- fetchSignature entry pos
+    let sigs = [sig]
+        activeSig = 0
+        activeParam = 0 -- TODO
+    return $ J.SignatureHelp (J.List sigs) (Just activeSig) (Just activeParam)
+
+fetchSignature :: I.ModuleStoreEntry -> J.Position -> IO J.SignatureInformation
+fetchSignature entry pos = do
+    -- TODO
+    return $ J.SignatureInformation "Test" Nothing Nothing Nothing

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -7,18 +7,24 @@ import qualified Curry.Syntax as CS
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
+import Curry.LanguageServer.Index.Resolve (resolveQualIdent)
 import qualified Curry.LanguageServer.Index.Store as I
+import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Monad
-import Curry.LanguageServer.Utils.Convert (ppToText)
 import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe)
+import Curry.LanguageServer.Utils.Sema (ModuleAST)
 import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
-import Data.Maybe (fromMaybe)
+import Data.Foldable (find)
+import Data.Maybe (fromMaybe, listToMaybe, maybeToList)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
 import qualified Language.LSP.Types.Lens as J
 import System.Log.Logger
+
+import Debug.Trace
+import Curry.LanguageServer.Utils.Convert (ppToString)
 
 signatureHelpHandler :: S.Handlers LSM
 signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req responder -> do
@@ -26,25 +32,37 @@ signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req resp
     let J.SignatureHelpParams doc pos _ _ = req ^. J.params
         uri = doc ^. J.uri
     normUri <- liftIO $ normalizeUriWithPath uri
+    store <- getStore
     sigHelp <- runMaybeT $ do
         entry <- I.getModule normUri
-        liftMaybe =<< (liftIO $ fetchSignatureHelp entry pos)
+        liftMaybe =<< (liftIO $ fetchSignatureHelp store entry pos)
     responder $ Right $ fromMaybe emptyHelp sigHelp
     where emptyHelp = J.SignatureHelp (J.List []) Nothing Nothing
 
-fetchSignatureHelp :: I.ModuleStoreEntry -> J.Position -> IO (Maybe J.SignatureHelp)
-fetchSignatureHelp entry pos = runMaybeT $ do
-    let ast = I.mseModuleAST entry
-        exprs = elementsAt pos $ expressions ast
+fetchSignatureHelp :: I.IndexStore -> I.ModuleStoreEntry -> J.Position -> IO (Maybe J.SignatureHelp)
+fetchSignatureHelp store entry pos = runMaybeT $ do
+    ast <- liftMaybe $ I.mseModuleAST entry
+    let exprs = elementsAt pos $ expressions ast
     -- TODO: Type applications?
-    -- TODO: Extract types rather than printing the values
-    (e1, e2) <- liftMaybe $ lastSafe [(e1, e2) | CS.Apply _ e1 e2 <- exprs]
-    let activeSig = 0
-        activeParam | elementContains pos e1 = 0
-                    | otherwise              = 1
-        paramLabels = ppToText <$> [e1, e2]
+    (sym, args) <- liftMaybe $ lastSafe $ do
+        e@(CS.Apply _ _ _) <- exprs
+        let base : args = appFull e
+        traceM $ "Signature help expr: " ++ ppToString e ++ ", base: " ++ ppToString base ++ ", args: " ++ show (ppToString <$> args)
+        traceM $ "Base is " ++ show base
+        sym <- maybeToList $ lookupExpression store ast base
+        traceM $ "Found symbol " ++ show sym
+        return (sym, args)
+    let activeParam = maybe 0 fst $ find (elementContains pos . snd) (zip [0..] args)
+        activeSig = 0
+        paramLabels = I.sPrintedArgumentTypes sym
         params = flip J.ParameterInformation Nothing . J.ParameterLabelString <$> paramLabels
         label = T.intercalate " -> " paramLabels
         sig = J.SignatureInformation label Nothing (Just $ J.List params) (Just activeParam)
         sigs = [sig]
     return $ J.SignatureHelp (J.List sigs) (Just activeSig) (Just activeParam)
+
+lookupExpression :: I.IndexStore -> ModuleAST -> CS.Expression a -> Maybe I.Symbol
+lookupExpression store ast e = listToMaybe $ case e of
+    CS.Variable _ _ q    -> resolveQualIdent store ast q
+    CS.Constructor _ _ q -> resolveQualIdent store ast q
+    _                    -> []

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -14,7 +14,7 @@ import Curry.LanguageServer.Index.Resolve (resolveQualIdent)
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Monad
-import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe, snapToLastTokenStart)
+import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe, snapToLastTokenEnd)
 import Curry.LanguageServer.Utils.Sema (ModuleAST)
 import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
@@ -48,7 +48,7 @@ fetchSignatureHelp :: I.IndexStore -> I.ModuleStoreEntry -> VFS.VirtualFile -> J
 fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
     ast <- liftMaybe $ I.mseModuleAST entry
     let line = VFS.rangeLinesFromVfs vfile $ J.Range (J.Position l 0) (J.Position (l + 1) 0)
-        c'   = snapToLastTokenStart (T.unpack line) c
+        c'   = snapToLastTokenEnd (T.unpack line) c
         pos' = J.Position l c'
     (sym, args) <- liftMaybe $  findExpressionApplication store ast pos'
                             <|> findTypeApplication       store ast pos'

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -1,13 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.SignatureHelp (signatureHelpHandler) where
 
+-- Curry Compiler Libraries + Dependencies
+import qualified Curry.Syntax as CS
+
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Maybe (runMaybeT)
+import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (..))
 import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad
+import Curry.LanguageServer.Utils.Convert (ppToText)
+import Curry.LanguageServer.Utils.General (liftMaybe, lastSafe)
+import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
 import qualified Language.LSP.Types.Lens as J
@@ -21,19 +28,23 @@ signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req resp
     normUri <- liftIO $ normalizeUriWithPath uri
     sigHelp <- runMaybeT $ do
         entry <- I.getModule normUri
-        liftIO $ fetchSignatureHelp entry pos
+        liftMaybe =<< (liftIO $ fetchSignatureHelp entry pos)
     responder $ Right $ fromMaybe emptyHelp sigHelp
     where emptyHelp = J.SignatureHelp (J.List []) Nothing Nothing
 
-fetchSignatureHelp :: I.ModuleStoreEntry -> J.Position -> IO J.SignatureHelp
-fetchSignatureHelp entry pos = do
-    sig <- fetchSignature entry pos
-    let sigs = [sig]
-        activeSig = 0
-        activeParam = 0 -- TODO
+fetchSignatureHelp :: I.ModuleStoreEntry -> J.Position -> IO (Maybe J.SignatureHelp)
+fetchSignatureHelp entry pos = runMaybeT $ do
+    let ast = I.mseModuleAST entry
+        exprs = elementsAt pos $ expressions ast
+    -- TODO: Type applications?
+    -- TODO: Extract types rather than printing the values
+    (e1, e2) <- liftMaybe $ lastSafe [(e1, e2) | CS.Apply _ e1 e2 <- exprs]
+    let activeSig = 0
+        activeParam | elementContains pos e1 = 0
+                    | otherwise              = 1
+        paramLabels = ppToText <$> [e1, e2]
+        params = flip J.ParameterInformation Nothing . J.ParameterLabelString <$> paramLabels
+        label = T.intercalate " -> " paramLabels
+        sig = J.SignatureInformation label Nothing (Just $ J.List params) (Just activeParam)
+        sigs = [sig]
     return $ J.SignatureHelp (J.List sigs) (Just activeSig) (Just activeParam)
-
-fetchSignature :: I.ModuleStoreEntry -> J.Position -> IO J.SignatureInformation
-fetchSignature entry pos = do
-    -- TODO
-    return $ J.SignatureInformation "Test" Nothing Nothing Nothing

--- a/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/SignatureHelp.hs
@@ -70,16 +70,14 @@ fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
 
 findExpressionApplication :: I.IndexStore -> ModuleAST -> J.Position -> Maybe (I.Symbol, CSPI.SpanInfo, [CSPI.SpanInfo])
 findExpressionApplication store ast pos = lastSafe $ do
-    let exprs = elementsAt pos $ expressions ast
-    e@(CS.Apply _ _ _) <- exprs
+    e <- elementsAt pos $ expressions ast
     let base : args = appFull e
     sym <- maybeToList $ lookupBaseExpression store ast base
     return (sym, CSPI.getSpanInfo e, CSPI.getSpanInfo <$> args)
 
 findTypeApplication :: I.IndexStore -> ModuleAST -> J.Position -> Maybe (I.Symbol, CSPI.SpanInfo, [CSPI.SpanInfo])
 findTypeApplication store ast pos = lastSafe $ do
-    let ts = elementsAt pos $ typeExpressions ast
-    e@(CS.ApplyType _ _ _) <- ts
+    e <- elementsAt pos $ typeExpressions ast
     let base : args = typeAppFull e
     sym <- maybeToList $ lookupBaseTypeExpression store ast base
     return (sym, CSPI.getSpanInfo e, CSPI.getSpanInfo <$> args)

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -70,6 +70,7 @@ makeValueSymbol k q t = do
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText t
         , sPrintedArgumentTypes = ppToText <$> CT.arrowArgs (CT.rawType t)
+        , sPrintedResultType = Just $ ppToText $ CT.arrowBase (CT.rawType t)
         , sArrowArity = Just $ CT.arrowArity $ CT.rawType t
         , sLocation = loc
         }
@@ -83,6 +84,9 @@ makeTypeSymbol k q k' = do
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText k'
         , sPrintedArgumentTypes = ppToText <$> CK.kindArgs k'
+        , sPrintedResultType = Just $ ppToText $ kindBase k'
         , sArrowArity = Just $ CK.kindArity k'
         , sLocation = loc
         }
+    where kindBase (CK.KindArrow _ k'') = kindBase k''
+          kindBase k''                  = k''

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -5,6 +5,8 @@ module Curry.LanguageServer.Index.Convert
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
+import qualified Base.CurryKinds as CKS
+import qualified Base.CurryTypes as CTS
 import qualified Base.TopEnv as CTE
 import qualified Base.Types as CT
 import qualified Base.Kinds as CK
@@ -14,7 +16,7 @@ import qualified Env.Value as CEV
 import Control.Applicative ((<|>))
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Curry.LanguageServer.Index.Symbol (Symbol (..), SymbolKind (..))
-import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
+import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location, ppToTextPrec)
 import Curry.LanguageServer.Utils.General (lastSafe)
 import Data.Default (Default (..))
 import Data.List (inits)
@@ -69,7 +71,9 @@ makeValueSymbol k q t = do
         , sQualIdent = ppToText q
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText t
-        , sPrintedArgumentTypes = ppToText <$> CT.arrowArgs (CT.rawType t)
+        -- We explicitly perform the Type -> TypeExpr conversion here since
+        -- the Pretty Type instance ignores the precedence.
+        , sPrintedArgumentTypes = ppToTextPrec 2 . CTS.fromType CI.identSupply <$> CT.arrowArgs (CT.rawType t)
         , sPrintedResultType = Just $ ppToText $ CT.arrowBase (CT.rawType t)
         , sArrowArity = Just $ CT.arrowArity $ CT.rawType t
         , sLocation = loc
@@ -83,7 +87,9 @@ makeTypeSymbol k q k' = do
         , sQualIdent = ppToText q
         , sIdent = ppToText $ CI.qidIdent q
         , sPrintedType = Just $ ppToText k'
-        , sPrintedArgumentTypes = ppToText <$> CK.kindArgs k'
+        -- We explicitly perform the Kind conversion here since
+        -- the Pretty Kind instance ignores the precedence.
+        , sPrintedArgumentTypes = ppToTextPrec 2 . CKS.fromKind <$> CK.kindArgs k'
         , sPrintedResultType = Just $ ppToText $ kindBase k'
         , sArrowArity = Just $ CK.kindArity k'
         , sLocation = loc

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -32,6 +32,7 @@ data Symbol = Symbol
     , sIdent :: T.Text
     , sPrintedType :: Maybe T.Text
     , sPrintedArgumentTypes :: [T.Text]
+    , sPrintedResultType :: Maybe T.Text
     , sArrowArity :: Maybe Int
     , sConstructors :: [T.Text]
     , sLocation :: Maybe J.Location
@@ -45,6 +46,7 @@ instance Default Symbol where
         , sIdent = ""
         , sPrintedType = Nothing
         , sPrintedArgumentTypes = []
+        , sPrintedResultType = Nothing
         , sArrowArity = Nothing
         , sConstructors = []
         , sLocation = Nothing

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -19,6 +19,8 @@ module Curry.LanguageServer.Utils.Convert
     , setCurryPosUri
     , setCurrySpanUri
     , setCurrySpanInfoUri
+    , ppToStringPrec
+    , ppToTextPrec
     , ppToString
     , ppToText
     , ppTypeSchemeToText
@@ -154,6 +156,12 @@ setCurrySpanInfoUri uri x@(CSPI.getSpanInfo -> spi@CSPI.SpanInfo {..}) = do
     spn <- setCurrySpanUri uri srcSpan
     return $ CSPI.setSpanInfo spi { CSPI.srcSpan = spn } x
 setCurrySpanInfoUri _ x = Just x
+
+ppToStringPrec :: CPP.Pretty p => Int -> p -> String
+ppToStringPrec p = PP.render . CPP.pPrintPrec p
+
+ppToTextPrec :: CPP.Pretty p => Int -> p -> T.Text
+ppToTextPrec p = T.pack . ppToStringPrec p
 
 ppToString :: CPP.Pretty p => p -> String
 ppToString = PP.render . CPP.pPrint

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -19,6 +19,7 @@ module Curry.LanguageServer.Utils.General
     , removeSingle
     , nothingIfNull
     , replaceString
+    , snapToLastToken
     , Insertable (..)
     , ConstMap (..)
     , insertIntoTrieWith
@@ -36,7 +37,7 @@ import qualified Data.ByteString as B
 import Data.Bifunctor (first, second)
 import Data.Char (isSpace)
 import qualified Data.List as L
-import Data.Foldable (foldrM)
+import Data.Foldable (foldrM, toList)
 import qualified Data.Text as T
 import qualified Data.Trie as TR
 import qualified Data.Map as M
@@ -178,6 +179,11 @@ nothingIfNull xs = Just xs
 
 replaceString :: String -> String -> String -> String
 replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
+
+-- | Moves a cursor back until a non-whitespace character precedes it.
+snapToLastToken :: Foldable f => f Char -> Int -> Int
+snapToLastToken s n = n - delta
+    where delta = length $ takeWhile isSpace $ reverse $ take n $ toList s
 
 class Insertable m a | m -> a where
     -- | Inserts a single entry.

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -19,7 +19,8 @@ module Curry.LanguageServer.Utils.General
     , removeSingle
     , nothingIfNull
     , replaceString
-    , snapToLastToken
+    , snapToLastTokenStart
+    , snapToLastTokenEnd
     , Insertable (..)
     , ConstMap (..)
     , insertIntoTrieWith
@@ -180,10 +181,16 @@ nothingIfNull xs = Just xs
 replaceString :: String -> String -> String -> String
 replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
 
--- | Moves a cursor back until a non-whitespace character precedes it.
-snapToLastToken :: String -> Int -> Int
-snapToLastToken s n = n - delta
-    where delta = length $ takeWhile isSpace $ reverse $ take n s
+-- | Moves the cursor back until the beginning of the last token.
+snapToLastTokenStart :: String -> Int -> Int
+snapToLastTokenStart = snapBack $ dropWhile (not . isSpace) . dropWhile isSpace
+
+-- | Moves the cursor back until a non-whitespace character precedes it (i.e. past the end of the last token).
+snapToLastTokenEnd :: String -> Int -> Int
+snapToLastTokenEnd = snapBack $ dropWhile isSpace
+
+snapBack :: ([a] -> [a]) -> [a] -> Int -> Int
+snapBack f s n = length $ f $ reverse $ take n s
 
 class Insertable m a | m -> a where
     -- | Inserts a single entry.

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -181,9 +181,9 @@ replaceString :: String -> String -> String -> String
 replaceString n r = T.unpack . T.replace (T.pack n) (T.pack r) . T.pack
 
 -- | Moves a cursor back until a non-whitespace character precedes it.
-snapToLastToken :: Foldable f => f Char -> Int -> Int
+snapToLastToken :: String -> Int -> Int
 snapToLastToken s n = n - delta
-    where delta = length $ takeWhile isSpace $ reverse $ take n $ toList s
+    where delta = length $ takeWhile isSpace $ reverse $ take n s
 
 class Insertable m a | m -> a where
     -- | Inserts a single entry.

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteString as B
 import Data.Bifunctor (first, second)
 import Data.Char (isSpace)
 import qualified Data.List as L
-import Data.Foldable (foldrM, toList)
+import Data.Foldable (foldrM)
 import qualified Data.Text as T
 import qualified Data.Trie as TR
 import qualified Data.Map as M

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -13,6 +13,8 @@ module Curry.LanguageServer.Utils.Syntax
     , moduleIdentifier
     , appBase
     , appFull
+    , typeAppBase
+    , typeAppFull
     ) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -50,6 +52,16 @@ appFull :: CS.Expression a -> [CS.Expression a]
 appFull = appFull' [] 
     where appFull' acc (CS.Apply _ e1 e2) = appFull' (e2 : acc) e1
           appFull' acc e                  = e : acc
+
+-- | Finds the base type that others have been applied to.
+typeAppBase :: CS.TypeExpr -> CS.TypeExpr
+typeAppBase = head . typeAppFull
+
+-- | Finds the full type application (i.e. the head and the args).
+typeAppFull :: CS.TypeExpr -> [CS.TypeExpr]
+typeAppFull = typeAppFull' [] 
+    where typeAppFull' acc (CS.ApplyType _ t1 t2) = typeAppFull' (t2 : acc) t1
+          typeAppFull' acc e                  = e : acc
 
 class HasExpressions s a | s -> a where
     -- | Fetches all expressions as pre-order traversal

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -11,6 +11,8 @@ module Curry.LanguageServer.Utils.Syntax
     , elementsAt
     , elementContains
     , moduleIdentifier
+    , appHead
+    , appFull
     ) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -38,6 +40,16 @@ elementContains pos = maybe False (rangeElem pos) . currySpanInfo2Range . CSPI.g
 -- | Fetches the module identifier for a module.
 moduleIdentifier :: CS.Module a -> CI.ModuleIdent
 moduleIdentifier (CS.Module _ _ _ ident _ _ _) = ident
+
+-- | Finds the base expression that others have been applied to.
+appHead :: CS.Expression a -> CS.Expression a
+appHead = head . appFull
+
+-- | Finds the full expression application (i.e. the head and the args).
+appFull :: CS.Expression a -> [CS.Expression a]
+appFull = appFull' [] 
+    where appFull' acc (CS.Apply _ e1 e2) = appFull' (e2 : acc) e1
+          appFull' acc e                  = e : acc
 
 class HasExpressions s a | s -> a where
     -- | Fetches all expressions as pre-order traversal

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -11,7 +11,7 @@ module Curry.LanguageServer.Utils.Syntax
     , elementsAt
     , elementContains
     , moduleIdentifier
-    , appHead
+    , appBase
     , appFull
     ) where
 
@@ -42,8 +42,8 @@ moduleIdentifier :: CS.Module a -> CI.ModuleIdent
 moduleIdentifier (CS.Module _ _ _ ident _ _ _) = ident
 
 -- | Finds the base expression that others have been applied to.
-appHead :: CS.Expression a -> CS.Expression a
-appHead = head . appFull
+appBase :: CS.Expression a -> CS.Expression a
+appBase = head . appFull
 
 -- | Finds the full expression application (i.e. the head and the args).
 appFull :: CS.Expression a -> [CS.Expression a]

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -8,6 +8,8 @@ module Curry.LanguageServer.Utils.Syntax
     , HasQualIdentifier (..)
     , HasIdentifier (..)
     , elementAt
+    , elementsAt
+    , elementContains
     , moduleIdentifier
     ) where
 
@@ -23,7 +25,11 @@ import qualified Language.LSP.Types as J
 
 -- | Fetches the element at the given position.
 elementAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> Maybe e
-elementAt pos = lastSafe . filter (elementContains pos)
+elementAt pos = lastSafe . elementsAt pos
+
+-- | Fetches the elements at the given position.
+elementsAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> [e]
+elementsAt pos = filter $ elementContains pos
 
 -- | Tests whether the given element in the AST contains the given position.
 elementContains :: CSPI.HasSpanInfo e => J.Position -> e -> Bool


### PR DESCRIPTION
## Fixes #9

This branch contains an experimental implementation of LSP's signature help for Curry:

![image](https://user-images.githubusercontent.com/30873659/115099579-2fdd9300-9f37-11eb-802d-4647ba246302.png)

Although the signature help works as intended, the popup may disappear if the user types quickly (faster than the compilation debouncer), since the position of the token below the cursor may no longer be in an expressions of the previously compiled (now outdated) AST.