### PR TITLE
Implement semantic tokens

### DIFF
--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -8,6 +8,7 @@ import Curry.LanguageServer.Handlers.Definition (definitionHandler)
 import Curry.LanguageServer.Handlers.DocumentSymbols (documentSymbolHandler)
 import Curry.LanguageServer.Handlers.Hover (hoverHandler)
 import Curry.LanguageServer.Handlers.Initialized (initializedHandler)
+import Curry.LanguageServer.Handlers.SemanticTokens (semanticTokensHandler)
 import Curry.LanguageServer.Handlers.SignatureHelp (signatureHelpHandler)
 import Curry.LanguageServer.Handlers.TextDocument (didOpenHandler, didChangeHandler, didSaveHandler, didCloseHandler)
 import Curry.LanguageServer.Handlers.WorkspaceSymbols (workspaceSymbolHandler)
@@ -26,6 +27,7 @@ handlers = mconcat
     , codeActionHandler
     , codeLensHandler
     , signatureHelpHandler
+    , semanticTokensHandler
       -- Notification handlers
     , initializedHandler
     , didOpenHandler

--- a/src/Curry/LanguageServer/Handlers/SemanticTokens.hs
+++ b/src/Curry/LanguageServer/Handlers/SemanticTokens.hs
@@ -3,7 +3,9 @@ module Curry.LanguageServer.Handlers.SemanticTokens (semanticTokensHandler) wher
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Curry.LanguageServer.Monad
+import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
+import Data.Maybe (fromMaybe)
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Types as J
 import qualified Language.LSP.Types.Lens as J
@@ -17,3 +19,8 @@ semanticTokensHandler = S.requestHandler J.STextDocumentSemanticTokensFull $ \re
     normUri <- liftIO $ normalizeUriWithPath uri
     store <- getStore
     responder $ Right $ Just $ J.SemanticTokens Nothing $ J.List []
+
+fetchSemanticTokens :: I.ModuleStoreEntry -> [J.SemanticTokenAbsolute]
+fetchSemanticTokens entry = fromMaybe [] $ do
+    ast <- I.mseModuleAST entry
+    return []

--- a/src/Curry/LanguageServer/Handlers/SemanticTokens.hs
+++ b/src/Curry/LanguageServer/Handlers/SemanticTokens.hs
@@ -1,0 +1,19 @@
+module Curry.LanguageServer.Handlers.SemanticTokens (semanticTokensHandler) where
+
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (liftIO)
+import Curry.LanguageServer.Monad
+import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
+import qualified Language.LSP.Server as S
+import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
+import System.Log.Logger
+
+semanticTokensHandler :: S.Handlers LSM
+semanticTokensHandler = S.requestHandler J.STextDocumentSemanticTokensFull $ \req responder -> do
+    liftIO $ debugM "cls.semanticTokens" "Processing semantic tokens request"
+    let doc = req ^. J.params . J.textDocument
+        uri = doc ^. J.uri
+    normUri <- liftIO $ normalizeUriWithPath uri
+    store <- getStore
+    responder $ Right $ Just $ J.SemanticTokens Nothing $ J.List []


### PR DESCRIPTION
### Fixes #39

Provide semantic highlighting in Curry documents.

To do:
- [x] Add semantic tokens request for full documents
- [x] Implement `HasSemanticTokens` for syntax tree nodes containing `Ident`s
- [ ] Implement `HasSemanticTokens` for syntax tree nodes containing `QualIdent`s (see `HasQualIdentifiers` for examples)
- [ ] Fix responsiveness issues: Currently, the AST in the index store may become out-of-sync with what the user types. Fully responsive semantic tokens may require us to implement something similar to #16 where a (possibly broken) AST is parsed in real-time.

Future work:
- Implement delta semantic tokens (investigate how much the `lsp` abstracts away for us there)