### PR TITLE
Use project-local `.curry` as output directory if workspace contains multiple projects

### DIFF
--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -260,7 +260,7 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
     ms <- gets idxModules
 
     let defEntry = def { mseProjectDir = dirPath, mseImportPaths = importPaths }
-        outDirPath = CFN.defaultOutDir </> "language-server"
+        outDirPath = maybe CFN.defaultOutDir (</> ".curry") dirPath </> "language-server"
         importPaths' = outDirPath : mseImportPaths (M.findWithDefault defEntry uri ms)
         aux = C.CompileAuxiliary { C.fileLoader = fl }
 


### PR DESCRIPTION
Consider the following project layout

```
<workspace>
├─ .curry
├─ project1
│  ├─ .curry
│  ├─ src
│  └─ package.json
└─ project2
   ├─ .curry
   ├─ src
   └─ package.json
```

Currently, the language server will use `<workspace>/.curry` as an output directory in any case since `defaultOutDir` points to `./.curry` and the language server's working directory is the workspace:

https://github.com/fwcd/curry-language-server/blob/668edfc7fe34e1023549a61a84d94a2a63cec97e/src/Curry/LanguageServer/Index/Store.hs#L261

Given that the user will compile projects anyway from their respective subdirectories, it would make sense for the language server to use the local `.curry` directories as well, which is what this PR does. This additionally prevents clashes if the user has a module under the same name in multiple packages and unexpected cross-visibility between packages in the same workspace once compiled.

Some more testing is needed, however, especially to make sure that dependencies use the correct out dir too etc.