### PR TITLE
Add support for origin pragmas

### DIFF
--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -118,6 +118,7 @@ compileCurryFileWithDeps cfg aux importPaths outDirPath filePath = (fromMaybe me
                                  , CO.optLibraryPaths = CFG.cfgLibraryPaths cfg
                                  , CO.optCppOpts = cppOpts { CO.cppDefinitions = cppDefs }
                                  , CO.optExtensions = nub $ CSE.kielExtensions ++ CO.optExtensions defOpts
+                                 , CO.optOriginPragmas = True
                                  }
     -- Resolve dependencies
     deps <- liftCYIO $ CD.flatDeps opts filePath

--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -146,8 +146,8 @@ compileCurryModule opts outDirPath m fp = do
     mdl <- loadAndCheckCurryModule opts m fp
     -- Generate and store an on-disk interface file
     mdl' <- CC.expandExports opts mdl
-    let interf = uncurry CEX.exportInterface $ CT.qual mdl'
-        interfFilePath = outDirPath </> CFN.interfName (CFN.moduleNameToFile m)
+    interf <- liftCYIO $ uncurry (CEX.exportInterface opts) $ CT.qual mdl'
+    let interfFilePath = outDirPath </> CFN.interfName (CFN.moduleNameToFile m)
         generated = PP.render $ CS.pPrint interf
     liftToCM $ debugM $ "Writing interface file to " <> T.pack interfFilePath
     liftIO $ CF.writeModule interfFilePath generated 

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
   - lsp-1.6.0.0
   - co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
+    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
   - lsp-1.6.0.0
   - co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: d61f3cf3604332fff026056ab22937203a5420f1
+    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,15 +26,15 @@ packages:
   original:
     hackage: co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
 - completed:
-    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
+    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 816e1d23495dcb8a98a4ded6c7ff50927f6efd6d87a85da1b50c2faf93f3df4c
+      sha256: 04f6cc0c503b005649d028434ad9c076f24d018dcd8ba8f877c2d7dd75f3f774
       size: 17097
     version: 2.1.0
   original:
-    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
+    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,15 +26,15 @@ packages:
   original:
     hackage: co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
 - completed:
-    commit: d61f3cf3604332fff026056ab22937203a5420f1
+    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 2961c26a8307c515ef47a8381b6d10e07737bf123fddce3b4696d84ef0ec8d5a
-      size: 16480
-    version: 2.0.0
+      sha256: 816e1d23495dcb8a98a4ded6c7ff50927f6efd6d87a85da1b50c2faf93f3df4c
+      size: 17097
+    version: 2.1.0
   original:
-    commit: d61f3cf3604332fff026056ab22937203a5420f1
+    commit: 1f36d2614b31a5b0c7b303072dc388ea7881f140
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:


### PR DESCRIPTION
### Fixes #26

The Curry frontend now supports generating source mappings in the form of origin pragmas as part of Curry interfaces, which we can use to resolve the proper source location of symbols. Specifically, if a `Prelude.icurry` exists (from previous compilations by the language server), symbols from the `Prelude` will still link to `Prelude.curry`.