### PR TITLE
Migrate to LTS 22.30 (GHC 9.6) and `lsp` 2.7

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,7 +7,7 @@ import qualified Data.Aeson as A
 import Data.Default (Default (..))
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 import qualified Curry.LanguageServer.Config as CFG
 import Curry.LanguageServer.Handlers
 import Curry.LanguageServer.Handlers.Workspace.Command (commands)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -25,18 +25,22 @@ runLanguageServer = do
     state <- newLSStateVar
     S.runServerWithHandles logger logger stdin stdout $ S.ServerDefinition
         { S.defaultConfig = def
-        , S.onConfigurationChange = \_old v -> case A.fromJSON v of
+        , S.parseConfig = \_old v -> case A.fromJSON v of
                                             A.Error e -> Left $ T.pack e
                                             A.Success cfg -> Right (cfg :: CFG.Config)
+        , S.configSection = "curry"
+        -- TODO: Handle configuration changes (ideally from here, not in the didChangeConfiguration handler)
+        -- See https://hackage.haskell.org/package/lsp-2.7.0.0/docs/Language-LSP-Server.html#t:ServerDefinition
+        , S.onConfigChange = const $ pure ()
         , S.doInitialize = const . pure . Right
         , S.staticHandlers = handlers
         , S.interpretHandler = \env -> S.Iso (\lsm -> runLSM lsm state env) liftIO
         , S.options = S.defaultOptions
-            { S.textDocumentSync = Just syncOptions
-            , S.completionTriggerCharacters = Just ['.']
-            , S.signatureHelpTriggerCharacters = Just [' ', '(', ')']
-            , S.executeCommandCommands = Just $ fst <$> commands
-            , S.serverInfo = Just $ J.ServerInfo "Curry Language Server" Nothing
+            { S.optTextDocumentSync = Just syncOptions
+            , S.optCompletionTriggerCharacters = Just ['.']
+            , S.optSignatureHelpTriggerCharacters = Just [' ', '(', ')']
+            , S.optExecuteCommandCommands = Just $ fst <$> commands
+            , S.optServerInfo = Just $ J.ServerInfo "Curry Language Server" Nothing
             }
         }
     where
@@ -50,7 +54,7 @@ runLanguageServer = do
         logger = LogAction $ const $ return ()
         syncOptions = J.TextDocumentSyncOptions
                         (Just True) -- open/close notifications
-                        (Just J.TdSyncIncremental) -- changes
+                        (Just J.TextDocumentSyncKind_Incremental) -- changes
                         (Just False) -- will save
                         (Just False) -- will save (wait until requests are sent to server)
                         (Just $ J.InR $ J.SaveOptions $ Just False) -- save

--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -60,6 +60,7 @@ library
       Curry.LanguageServer.Utils.Sema
       Curry.LanguageServer.Utils.Syntax
       Curry.LanguageServer.Utils.Uri
+      Curry.LanguageServer.Utils.VFS
   other-modules:
       Paths_curry_language_server
   hs-source-dirs:
@@ -90,6 +91,7 @@ library
     , sorted-list ==0.2.*
     , stm ==2.5.*
     , text ==2.0.*
+    , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010
@@ -127,6 +129,7 @@ executable curry-language-server
     , sorted-list ==0.2.*
     , stm ==2.5.*
     , text ==2.0.*
+    , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010
@@ -165,6 +168,7 @@ test-suite curry-language-server-test
     , sorted-list ==0.2.*
     , stm ==2.5.*
     , text ==2.0.*
+    , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010

--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -82,7 +82,7 @@ library
     , extra ==1.7.*
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
-    , lsp ==2.3.*
+    , lsp ==2.7.*
     , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*
@@ -119,7 +119,7 @@ executable curry-language-server
     , extra ==1.7.*
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
-    , lsp ==2.3.*
+    , lsp ==2.7.*
     , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*
@@ -157,7 +157,7 @@ test-suite curry-language-server-test
     , extra ==1.7.*
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
-    , lsp ==2.3.*
+    , lsp ==2.7.*
     , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*

--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -67,9 +67,9 @@ library
   ghc-options: -Wall
   build-depends:
       Glob ==0.10.*
-    , aeson ==2.0.*
+    , aeson >=2.0 && <2.2
     , async ==2.2.*
-    , base ==4.16.*
+    , base >=4.16 && <4.19
     , bytestring ==0.11.*
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
@@ -81,16 +81,16 @@ library
     , exceptions ==0.10.*
     , extra ==1.7.*
     , filepath ==1.4.*
-    , lens ==5.1.*
-    , lsp ==1.6.*
-    , mtl ==2.2.*
+    , lens >=5.1 && <5.3
+    , lsp ==2.3.*
+    , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==1.2.*
-    , transformers ==0.5.*
+    , text ==2.0.*
+    , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010
 
@@ -103,9 +103,9 @@ executable curry-language-server
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
       Glob ==0.10.*
-    , aeson ==2.0.*
+    , aeson >=2.0 && <2.2
     , async ==2.2.*
-    , base ==4.16.*
+    , base >=4.16 && <4.19
     , bytestring ==0.11.*
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
@@ -118,16 +118,16 @@ executable curry-language-server
     , exceptions ==0.10.*
     , extra ==1.7.*
     , filepath ==1.4.*
-    , lens ==5.1.*
-    , lsp ==1.6.*
-    , mtl ==2.2.*
+    , lens >=5.1 && <5.3
+    , lsp ==2.3.*
+    , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==1.2.*
-    , transformers ==0.5.*
+    , text ==2.0.*
+    , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010
 
@@ -141,9 +141,9 @@ test-suite curry-language-server-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Glob ==0.10.*
-    , aeson ==2.0.*
+    , aeson >=2.0 && <2.2
     , async ==2.2.*
-    , base ==4.16.*
+    , base >=4.16 && <4.19
     , bytestring ==0.11.*
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
@@ -156,15 +156,15 @@ test-suite curry-language-server-test
     , exceptions ==0.10.*
     , extra ==1.7.*
     , filepath ==1.4.*
-    , lens ==5.1.*
-    , lsp ==1.6.*
-    , mtl ==2.2.*
+    , lens >=5.1 && <5.3
+    , lsp ==2.3.*
+    , mtl >=2.2 && <2.4
     , parsec >=3.1 && <4
     , pretty ==1.1.*
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==1.2.*
-    , transformers ==0.5.*
+    , text ==2.0.*
+    , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,7 @@ dependencies:
   - Glob            >= 0.10 && < 0.11
   - directory       >= 1.3  && < 1.4
   - sorted-list     >= 0.2  && < 0.3
-  - lsp             >= 2.3  && < 2.4
+  - lsp             >= 2.7  && < 2.8
   - unliftio-core   >= 0.2  && < 0.3
   - bytestring      >= 0.11 && < 0.12
   - bytestring-trie >= 0.2  && < 0.3

--- a/package.yaml
+++ b/package.yaml
@@ -13,25 +13,25 @@ extra-source-files:
   - README.md
 
 dependencies:
-  - base            >= 4.16 && < 4.17
-  - aeson           >= 2.0  && < 2.1
+  - base            >= 4.16 && < 4.19
+  - aeson           >= 2.0  && < 2.2
   - async           >= 2.2  && < 2.3
   - containers      >= 0.6  && < 0.7
   - data-default    >= 0.7  && < 0.8
   - extra           >= 1.7  && < 1.8
   - either          >= 5.0  && < 6
-  - mtl             >= 2.2  && < 2.3
-  - transformers    >= 0.5  && < 0.6
+  - mtl             >= 2.2  && < 2.4
+  - transformers    >= 0.5  && < 0.7
   - exceptions      >= 0.10 && < 0.11
   - stm             >= 2.5  && < 2.6
-  - text            >= 1.2  && < 1.3
-  - lens            >= 5.1  && < 5.2
+  - text            >= 2.0  && < 2.1
+  - lens            >= 5.1  && < 5.3
   - co-log-core     >= 0.3  && < 0.4
   - filepath        >= 1.4  && < 1.5
   - Glob            >= 0.10 && < 0.11
   - directory       >= 1.3  && < 1.4
   - sorted-list     >= 0.2  && < 0.3
-  - lsp             >= 1.6  && < 1.7
+  - lsp             >= 2.3  && < 2.4
   - unliftio-core   >= 0.2  && < 0.3
   - bytestring      >= 0.11 && < 0.12
   - bytestring-trie >= 0.2  && < 0.3

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - exceptions      >= 0.10 && < 0.11
   - stm             >= 2.5  && < 2.6
   - text            >= 2.0  && < 2.1
+  - text-rope       >= 0.2  && < 0.3
   - lens            >= 5.1  && < 5.3
   - co-log-core     >= 0.3  && < 0.4
   - filepath        >= 1.4  && < 1.5

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -14,10 +14,11 @@ import Curry.LanguageServer.Handlers.Workspace.Command (executeCommandHandler)
 import Curry.LanguageServer.Handlers.Workspace.Notifications (didChangeConfigurationHandler)
 import Curry.LanguageServer.Handlers.Workspace.Symbol (workspaceSymbolHandler)
 import Curry.LanguageServer.Monad (LSM)
+import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Server as S
 
-handlers :: S.Handlers LSM
-handlers = mconcat
+handlers :: J.ClientCapabilities -> S.Handlers LSM
+handlers _caps = mconcat
     [ -- Request handlers
       completionHandler
     , executeCommandHandler

--- a/src/Curry/LanguageServer/Handlers/Cancel.hs
+++ b/src/Curry/LanguageServer/Handlers/Cancel.hs
@@ -6,10 +6,10 @@ module Curry.LanguageServer.Handlers.Cancel
 import Curry.LanguageServer.Monad (LSM)
 import Curry.LanguageServer.Utils.Logging (debugM)
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Message as J
 
 cancelHandler :: S.Handlers LSM
-cancelHandler = S.notificationHandler J.SCancelRequest $ \_nt -> do
+cancelHandler = S.notificationHandler J.SMethod_CancelRequest $ \_nt -> do
     debugM "Processing cancel request"
     -- TODO: This is currently just a stub to prevent error messages
     --       about the unimplemented request from showing up, we might

--- a/src/Curry/LanguageServer/Handlers/Cancel.hs
+++ b/src/Curry/LanguageServer/Handlers/Cancel.hs
@@ -6,7 +6,7 @@ module Curry.LanguageServer.Handlers.Cancel
 import Curry.LanguageServer.Monad (LSM)
 import Curry.LanguageServer.Utils.Logging (debugM)
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 cancelHandler :: S.Handlers LSM
 cancelHandler = S.notificationHandler J.SCancelRequest $ \_nt -> do

--- a/src/Curry/LanguageServer/Handlers/Diagnostics.hs
+++ b/src/Curry/LanguageServer/Handlers/Diagnostics.hs
@@ -30,8 +30,8 @@ emitDiagnostics normUri entry = do
 
 fetchDiagnostics :: (MonadIO m, MonadLsp CFG.Config m) => J.NormalizedUri -> ModuleStoreEntry -> m [J.Diagnostic]
 fetchDiagnostics normUri entry = do
-    let warnings = map (curryMsg2Diagnostic J.DsWarning) entry.warningMessages
-        errors = map (curryMsg2Diagnostic J.DsError) entry.errorMessages
+    let warnings = map (curryMsg2Diagnostic J.DiagnosticSeverity_Warning) entry.warningMessages
+        errors = map (curryMsg2Diagnostic J.DiagnosticSeverity_Error) entry.errorMessages
         diags = warnings ++ errors
         name = maybe "?" takeBaseName $ normalizedUriToFilePath normUri
     

--- a/src/Curry/LanguageServer/Handlers/Diagnostics.hs
+++ b/src/Curry/LanguageServer/Handlers/Diagnostics.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as T
 import qualified Language.LSP.Diagnostics as D
 import qualified Language.LSP.Server as S
 import Language.LSP.Server (MonadLsp)
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 import System.FilePath (takeBaseName)
 
 emitDiagnostics :: J.NormalizedUri -> ModuleStoreEntry -> LSM ()

--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -10,16 +10,17 @@ import Data.Maybe (maybeToList, fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Message as J
 
 initializedHandler :: S.Handlers LSM
-initializedHandler = S.notificationHandler J.SInitialized $ \_nt -> do
+initializedHandler = S.notificationHandler J.SMethod_Initialized $ \_nt -> do
     infoM "Building index store..."
     workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
     let folders = maybeToList . folderToPath =<< workspaceFolders
     mapM_ addDirToIndexStore folders
     count <- I.getModuleCount
     infoM $ "Indexed " <> T.pack (show count) <> " files"
-    where folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath $ J.Uri uri
+    where folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri
 
 -- | Indexes a workspace folder recursively.
 addDirToIndexStore :: FilePath -> LSM ()

--- a/src/Curry/LanguageServer/Handlers/Initialized.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialized.hs
@@ -9,7 +9,7 @@ import Curry.LanguageServer.Monad (LSM)
 import Data.Maybe (maybeToList, fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 initializedHandler :: S.Handlers LSM
 initializedHandler = S.notificationHandler J.SInitialized $ \_nt -> do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
@@ -23,8 +23,8 @@ import Data.Maybe (fromMaybe, maybeToList)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import Language.LSP.Server (MonadLsp)
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 
 codeActionHandler :: S.Handlers LSM
 codeActionHandler = S.requestHandler J.STextDocumentCodeAction $ \req responder -> do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
@@ -35,7 +35,7 @@ codeActionHandler = S.requestHandler J.STextDocumentCodeAction $ \req responder 
     actions <- runMaybeT $ do
         entry <- I.getModule normUri
         lift $ fetchCodeActions range entry
-    responder $ Right $ J.List $ J.InR <$> fromMaybe [] actions
+    responder $ Right $ J.InR <$> fromMaybe [] actions
 
 fetchCodeActions :: (MonadIO m, MonadLsp CFG.Config m) => J.Range -> I.ModuleStoreEntry -> m [J.CodeAction]
 fetchCodeActions range entry = do
@@ -63,7 +63,7 @@ instance HasCodeActions (CS.Module (Maybe CT.PredType)) where
                 --       central place to avoid repetition.
                 let text = ppToText i <> " :: " <> ppToText t
                     args = [A.toJSON uri, A.toJSON $ range' ^. J.start, A.toJSON text]
-                    command = J.Command text "decl.applyTypeHint" $ Just $ J.List args
+                    command = J.Command text "decl.applyTypeHint" $ Just args
                     caKind = J.CodeActionQuickFix
                     isPreferred = True
                     lens = J.CodeAction ("Add type annotation '" <> text <> "'") (Just caKind) Nothing (Just isPreferred) Nothing Nothing (Just command) Nothing

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
@@ -21,8 +21,8 @@ import Data.Maybe (fromMaybe, maybeToList)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import Language.LSP.Server (MonadLsp)
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 
 codeLensHandler :: S.Handlers LSM
 codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
@@ -36,7 +36,7 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
         lenses <- runMaybeT $ do
             entry <- I.getModule normUri
             lift $ fetchCodeLenses entry
-        responder $ Right $ J.List $ fromMaybe [] lenses
+        responder $ Right $ fromMaybe [] lenses
 
 fetchCodeLenses :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.CodeLens]
 fetchCodeLenses entry = do
@@ -60,7 +60,7 @@ instance HasCodeLenses (CS.Module (Maybe CT.PredType)) where
                 --       central place to avoid repetition.
                 let text = ppToText i <> " :: " <> ppToText t
                     args = [A.toJSON uri, A.toJSON $ range ^. J.start, A.toJSON text]
-                    command = J.Command text "decl.applyTypeHint" $ Just $ J.List args
+                    command = J.Command text "decl.applyTypeHint" $ Just args
                     lens = J.CodeLens range (Just command) Nothing
                 return lens
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
@@ -23,9 +23,10 @@ import qualified Language.LSP.Server as S
 import Language.LSP.Server (MonadLsp)
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Lens as J
+import qualified Language.LSP.Protocol.Message as J
 
 codeLensHandler :: S.Handlers LSM
-codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> do
+codeLensHandler = S.requestHandler J.SMethod_TextDocumentCodeLens $ \req responder -> do
     debugM "Processing code lens request"
     let J.CodeLensParams _ _ doc = req ^. J.params
         uri = doc ^. J.uri
@@ -36,7 +37,7 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
         lenses <- runMaybeT $ do
             entry <- I.getModule normUri
             lift $ fetchCodeLenses entry
-        responder $ Right $ fromMaybe [] lenses
+        responder $ Right $ J.InL $ fromMaybe [] lenses
 
 fetchCodeLenses :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.CodeLens]
 fetchCodeLenses entry = do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -29,8 +29,8 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.VFS as VFS
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
 
 completionHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -58,7 +58,7 @@ completionHandler = S.requestHandler J.STextDocumentCompletion $ \req responder 
     let maxCompletions = 25
         items = take maxCompletions completions
         incomplete = length completions > maxCompletions
-        result = J.CompletionList incomplete $ J.List items
+        result = J.CompletionList incomplete items
     responder $ Right $ J.InR result
 
 fetchCompletions :: (MonadIO m, MonadLsp CFG.Config m) => CompletionOptions -> I.ModuleStoreEntry -> I.IndexStore -> VFS.PosPrefixInfo -> m [J.CompletionItem]
@@ -306,7 +306,7 @@ makeCompletion l k d c it itf es = J.CompletionItem label kind tags detail doc d
         insertTextFormat = itf
         insertTextMode = Nothing
         textEdit = Nothing
-        additionalTextEdits = J.List <$> es
+        additionalTextEdits = es
         commitChars = Nothing
         command = Nothing
         xdata = Nothing

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Definition.hs
@@ -33,7 +33,7 @@ definitionHandler = S.requestHandler J.STextDocumentDefinition $ \req responder 
         lift $ debugM $ "Looking up " <> J.getUri (J.fromNormalizedUri normUri) <> " in " <> T.pack (show (M.keys store.modules))
         entry <- I.getModule normUri
         lift $ fetchDefinitions store entry pos
-    responder $ Right $ J.InR $ J.InR $ J.List $ fromMaybe [] defs
+    responder $ Right $ J.InR $ J.InR $ fromMaybe [] defs
 
 fetchDefinitions :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> J.Position -> m [J.LocationLink]
 fetchDefinitions store entry pos = do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Definition.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Definition.hs
@@ -18,8 +18,8 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
 
 definitionHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
@@ -11,22 +11,22 @@ import Curry.LanguageServer.Utils.Logging (debugM)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import Curry.LanguageServer.Utils.Convert (HasDocumentSymbols(..))
 import Curry.LanguageServer.Monad (LSM)
-import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
+import qualified Language.LSP.Protocol.Message as J
 
 documentSymbolHandler :: S.Handlers LSM
-documentSymbolHandler = S.requestHandler J.STextDocumentDocumentSymbol $ \req responder -> do
+documentSymbolHandler = S.requestHandler J.SMethod_TextDocumentDocumentSymbol $ \req responder -> do
     debugM "Processing document symbols request"
     let uri = req ^. J.params . J.textDocument . J.uri
     normUri <- normalizeUriWithPath uri
     symbols <- runMaybeT $ do
         entry <- I.getModule normUri
         lift $ fetchDocumentSymbols entry
-    responder $ Right $ J.InL $ fromMaybe [] symbols
+    responder $ Right $ J.InR $ maybe (J.InR J.Null) J.InL symbols
 
 fetchDocumentSymbols :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.DocumentSymbol]
 fetchDocumentSymbols entry = do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
@@ -14,8 +14,8 @@ import Curry.LanguageServer.Monad (LSM)
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
 
 documentSymbolHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
@@ -26,7 +26,7 @@ documentSymbolHandler = S.requestHandler J.STextDocumentDocumentSymbol $ \req re
     symbols <- runMaybeT $ do
         entry <- I.getModule normUri
         lift $ fetchDocumentSymbols entry
-    responder $ Right $ J.InL $ J.List $ fromMaybe [] symbols
+    responder $ Right $ J.InL $ fromMaybe [] symbols
 
 fetchDocumentSymbols :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.DocumentSymbol]
 fetchDocumentSymbols entry = do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -23,8 +23,8 @@ import Curry.LanguageServer.Monad (LSM, getStore)
 import Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
 
 hoverHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot, ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot, TypeOperators, ViewPatterns #-}
 module Curry.LanguageServer.Handlers.TextDocument.Hover (hoverHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -25,10 +25,11 @@ import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Lens as J
+import qualified Language.LSP.Protocol.Message as J
 import Language.LSP.Server (MonadLsp)
 
 hoverHandler :: S.Handlers LSM
-hoverHandler = S.requestHandler J.STextDocumentHover $ \req responder -> do
+hoverHandler = S.requestHandler J.SMethod_TextDocumentHover $ \req responder -> do
     debugM "Processing hover request"
     let pos = req ^. J.params . J.position
         uri = req ^. J.params . J.textDocument . J.uri
@@ -37,7 +38,7 @@ hoverHandler = S.requestHandler J.STextDocumentHover $ \req responder -> do
     hover <- runMaybeT $ do
         entry <- I.getModule normUri
         MaybeT $ fetchHover store entry pos
-    responder $ Right hover
+    responder $ Right $ maybe (J.InR J.Null) J.InL hover
 
 fetchHover :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> J.Position -> m (Maybe J.Hover)
 fetchHover store entry pos = runMaybeT $ do
@@ -51,7 +52,7 @@ qualIdentHover store ast pos = do
     (symbols, range) <- resolveAtPos store ast pos
     s <- listToMaybe symbols
 
-    let contents = J.HoverContents $ J.markedUpContent "curry" $ s.qualIdent <> maybe "" (" :: " <>) s.printedType
+    let contents = J.InL $ J.mkMarkdownCodeBlock "curry" $ s.qualIdent <> maybe "" (" :: " <>) s.printedType
 
     return $ J.Hover contents $ Just range
 
@@ -59,14 +60,14 @@ typedSpanInfoHover :: ModuleAST -> J.Position -> Maybe J.Hover
 typedSpanInfoHover ast@(moduleIdentifier -> mid) pos = do
     TypedSpanInfo txt t spi <- findTypeAtPos ast pos
 
-    let contents = J.HoverContents $ J.markedUpContent "curry" $ txt <> " :: " <> maybe "?" (ppPredTypeToText mid) t
+    let contents = J.InL $ J.mkMarkdownCodeBlock "curry" $ txt <> " :: " <> maybe "?" (ppPredTypeToText mid) t
         range = currySpanInfo2Range spi
 
     return $ J.Hover contents range
 
 previewHover :: J.Hover -> T.Text
-previewHover ((^. J.contents) -> J.HoverContents (J.MarkupContent k t)) = case k of J.MkMarkdown  -> markdownToPlain t
-                                                                                    J.MkPlainText -> t
+previewHover ((^. J.contents) -> J.InL (J.MarkupContent k t)) = case k of J.MarkupKind_Markdown  -> markdownToPlain t
+                                                                          J.MarkupKind_PlainText -> t
 previewHover _                                                          = "?"
 
 markdownToPlain :: T.Text -> T.Text

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Notifications.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Notifications.hs
@@ -20,27 +20,28 @@ import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Lens as J
+import qualified Language.LSP.Protocol.Message as J
 
 didOpenHandler :: S.Handlers LSM
-didOpenHandler = S.notificationHandler J.STextDocumentDidOpen $ \nt -> do
+didOpenHandler = S.notificationHandler J.SMethod_TextDocumentDidOpen $ \nt -> do
     debugM "Processing open notification"
     let uri = nt ^. J.params . J.textDocument . J.uri
     updateIndexStoreDebounced uri
 
 didChangeHandler :: S.Handlers LSM
-didChangeHandler = S.notificationHandler J.STextDocumentDidChange $ \nt -> do
+didChangeHandler = S.notificationHandler J.SMethod_TextDocumentDidChange $ \nt -> do
     debugM "Processing change notification"
     let uri = nt ^. J.params . J.textDocument . J.uri
     updateIndexStoreDebounced uri
 
 didSaveHandler :: S.Handlers LSM
-didSaveHandler = S.notificationHandler J.STextDocumentDidSave $ \nt -> do
+didSaveHandler = S.notificationHandler J.SMethod_TextDocumentDidSave $ \nt -> do
     debugM "Processing save notification"
     let uri = nt ^. J.params . J.textDocument . J.uri
     updateIndexStoreDebounced uri
 
 didCloseHandler :: S.Handlers LSM
-didCloseHandler = S.notificationHandler J.STextDocumentDidClose $ \_nt -> do
+didCloseHandler = S.notificationHandler J.SMethod_TextDocumentDidClose $ \_nt -> do
     debugM "Processing close notification"
     -- TODO: Remove file from LSM state?
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Notifications.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Notifications.hs
@@ -18,8 +18,8 @@ import Curry.LanguageServer.Utils.Logging (debugM)
 import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 
 didOpenHandler :: S.Handlers LSM
 didOpenHandler = S.notificationHandler J.STextDocumentDidOpen $ \nt -> do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
@@ -49,7 +49,7 @@ signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req resp
         vfile <- MaybeT $ S.getVirtualFile normUri
         MaybeT $ fetchSignatureHelp store entry vfile pos
     responder $ Right $ fromMaybe emptyHelp sigHelp
-    where emptyHelp = J.SignatureHelp (J.List []) Nothing Nothing
+    where emptyHelp = J.SignatureHelp [] Nothing Nothing
 
 fetchSignatureHelp :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> VFS.VirtualFile -> J.Position -> m (Maybe J.SignatureHelp)
 fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
@@ -72,9 +72,9 @@ fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
         paramOffsets = reverse $ snd $ foldl (\(n, offs) lbl -> let n' = n + T.length lbl in (n' + T.length paramSep, (n, n') : offs)) (T.length labelStart, []) paramLabels
         params = flip J.ParameterInformation Nothing . uncurry J.ParameterLabelOffset . bimap fromIntegral fromIntegral <$> paramOffsets
         label = labelStart <> T.intercalate paramSep (paramLabels ++ maybeToList sym.printedResultType)
-        sig = J.SignatureInformation label Nothing (Just $ J.List params) (Just activeParam)
+        sig = J.SignatureInformation label Nothing (Just params) (Just activeParam)
         sigs = [sig]
-    return $ J.SignatureHelp (J.List sigs) (Just activeSig) (Just activeParam)
+    return $ J.SignatureHelp sigs (Just activeSig) (Just activeParam)
 
 findExpressionApplication :: I.IndexStore -> ModuleAST -> J.Position -> Maybe (I.Symbol, CSPI.SpanInfo, [CSPI.SpanInfo])
 findExpressionApplication store ast pos = lastSafe $ do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
@@ -72,9 +72,9 @@ fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
         paramOffsets = reverse $ snd $ foldl (\(n, offs) lbl -> let n' = n + T.length lbl in (n' + T.length paramSep, (n, n') : offs)) (T.length labelStart, []) paramLabels
         params = flip J.ParameterInformation Nothing . J.InR . bimap fromIntegral fromIntegral <$> paramOffsets
         label = labelStart <> T.intercalate paramSep (paramLabels ++ maybeToList sym.printedResultType)
-        sig = J.SignatureInformation label Nothing (Just params) (Just activeParam)
+        sig = J.SignatureInformation label Nothing (Just params) (Just (J.InL activeParam))
         sigs = [sig]
-    return $ J.SignatureHelp sigs (Just activeSig) (Just activeParam)
+    return $ J.SignatureHelp sigs (Just activeSig) (Just (J.InL activeParam))
 
 findExpressionApplication :: I.IndexStore -> ModuleAST -> J.Position -> Maybe (I.Symbol, CSPI.SpanInfo, [CSPI.SpanInfo])
 findExpressionApplication store ast pos = lastSafe $ do

--- a/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
@@ -32,8 +32,8 @@ import Data.Maybe (fromMaybe, listToMaybe, maybeToList)
 import qualified Data.List.NonEmpty as N
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import qualified Language.LSP.VFS as VFS
 import Language.LSP.Server (MonadLsp)
 

--- a/src/Curry/LanguageServer/Handlers/Workspace/Command.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Command.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings, ViewPatterns, TypeOperators #-}
 module Curry.LanguageServer.Handlers.Workspace.Command (executeCommandHandler, commands) where
 
 import Control.Lens ((^.))
@@ -10,38 +10,39 @@ import qualified Data.Text as T
 import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Lens as J
+import qualified Language.LSP.Protocol.Message as J
 
 executeCommandHandler :: S.Handlers LSM
-executeCommandHandler = S.requestHandler J.SWorkspaceExecuteCommand $ \req responder -> do
+executeCommandHandler = S.requestHandler J.SMethod_WorkspaceExecuteCommand $ \req responder -> do
     debugM "Processing command execution request"
     let J.ExecuteCommandParams _ name args = req ^. J.params
-    res <- executeCommand name $ maybe [] (\(J.List as) -> as) args
+    res <- executeCommand name $ maybe [] id args
     responder res
 
-executeCommand :: T.Text -> [A.Value] -> LSM (Either J.ResponseError A.Value)
+executeCommand :: T.Text -> [A.Value] -> LSM (Either J.ResponseError (A.Value J.|? J.Null))
 executeCommand name args = case lookup name commands of
     Just command -> command args
     Nothing -> do
         let msg = "Unknown command '" <> name <> "'"
         warnM msg
-        return $ Left $ J.ResponseError J.InvalidParams msg Nothing
+        return $ Left $ J.ResponseError (J.InR J.ErrorCodes_InvalidParams) msg Nothing
 
-commands :: [(T.Text, [A.Value] -> LSM (Either J.ResponseError A.Value))]
+commands :: [(T.Text, [A.Value] -> LSM (Either J.ResponseError (A.Value J.|? J.Null)))]
 commands =
     [ ("ping", \_args -> do
         infoM "Pong!"
-        return $ Right A.Null)
+        return $ Right $ J.InR J.Null)
     , ("decl.applyTypeHint", \args -> do
         case args of
             [A.fromJSON -> A.Success uri, A.fromJSON -> A.Success pos, A.fromJSON -> A.Success text] -> do
-                let doc = J.VersionedTextDocumentIdentifier uri $ Just 0
+                let doc = J.OptionalVersionedTextDocumentIdentifier uri $ J.InL 0
                     range = J.Range pos pos
                     textEdit = J.TextEdit range $ text <> "\n"
-                    docEdit = J.TextDocumentEdit doc $ J.List [J.InL textEdit]
+                    docEdit = J.TextDocumentEdit doc [J.InL textEdit]
                     docEdits = [docEdit]
-                    workspaceEdit = J.WorkspaceEdit Nothing (Just $ J.List $ J.InL <$> docEdits) Nothing
+                    workspaceEdit = J.WorkspaceEdit Nothing (Just $ J.InL <$> docEdits) Nothing
                     params = J.ApplyWorkspaceEditParams (Just "Apply Type Hint") workspaceEdit
-                void $ S.sendRequest J.SWorkspaceApplyEdit params (const $ pure ())
-                return $ Right A.Null
-            _ -> return $ Left $ J.ResponseError J.InvalidParams "Invalid arguments!" Nothing)
+                void $ S.sendRequest J.SMethod_WorkspaceApplyEdit params (const $ pure ())
+                return $ Right $ J.InR J.Null
+            _ -> return $ Left $ J.ResponseError (J.InR J.ErrorCodes_InvalidParams) "Invalid arguments!" Nothing)
     ]

--- a/src/Curry/LanguageServer/Handlers/Workspace/Command.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Command.hs
@@ -8,8 +8,8 @@ import Curry.LanguageServer.Utils.Logging (debugM, infoM, warnM)
 import qualified Data.Aeson as A
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 
 executeCommandHandler :: S.Handlers LSM
 executeCommandHandler = S.requestHandler J.SWorkspaceExecuteCommand $ \req responder -> do

--- a/src/Curry/LanguageServer/Handlers/Workspace/Notifications.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Notifications.hs
@@ -6,10 +6,10 @@ module Curry.LanguageServer.Handlers.Workspace.Notifications
 import Curry.LanguageServer.Monad (LSM)
 import Curry.LanguageServer.Utils.Logging (debugM)
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Message as J
 
 didChangeConfigurationHandler :: S.Handlers LSM
-didChangeConfigurationHandler = S.notificationHandler J.SWorkspaceDidChangeConfiguration $ \_nt -> do
+didChangeConfigurationHandler = S.notificationHandler J.SMethod_WorkspaceDidChangeConfiguration $ \_nt -> do
     debugM "Processing configuration change notification"
     -- TODO
     

--- a/src/Curry/LanguageServer/Handlers/Workspace/Notifications.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Notifications.hs
@@ -6,7 +6,7 @@ module Curry.LanguageServer.Handlers.Workspace.Notifications
 import Curry.LanguageServer.Monad (LSM)
 import Curry.LanguageServer.Utils.Logging (debugM)
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 didChangeConfigurationHandler :: S.Handlers LSM
 didChangeConfigurationHandler = S.notificationHandler J.SWorkspaceDidChangeConfiguration $ \_nt -> do

--- a/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
@@ -11,8 +11,8 @@ import Curry.LanguageServer.Utils.Logging (debugM, infoM)
 import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
 import qualified Language.LSP.Server as S
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Server (MonadLsp)
 
 workspaceSymbolHandler :: S.Handlers LSM

--- a/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
@@ -22,7 +22,7 @@ workspaceSymbolHandler = S.requestHandler J.SWorkspaceSymbol $ \req responder ->
     store <- getStore
     symbols <- fetchWorkspaceSymbols store query
     let maxSymbols = 150
-    responder $ Right $ J.List $ take maxSymbols symbols
+    responder $ Right $ take maxSymbols symbols
 
 fetchWorkspaceSymbols :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> T.Text -> m [J.SymbolInformation]
 fetchWorkspaceSymbols store query = do

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -14,7 +14,7 @@ import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
 import Curry.LanguageServer.Utils.Sema (ModuleAST)
 import Curry.LanguageServer.Utils.Lookup (findQualIdentAtPos, findModuleIdentAtPos)
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 -- | Resolves the identifier at the given position.
 resolveAtPos :: I.IndexStore -> ModuleAST -> J.Position -> Maybe ([I.Symbol], J.Range)

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -61,7 +61,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Data.Text.Encoding as TE
 import qualified Data.Trie as TR
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 import System.Directory (doesFileExist, doesDirectoryExist)
 import System.Exit (ExitCode(ExitSuccess))
 import System.FilePath ((<.>), (</>), takeDirectory, takeExtension, takeFileName)

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -34,6 +34,7 @@ import qualified Base.TopEnv as CT
 import qualified CompilerEnv as CE
 
 import Control.Exception (SomeException)
+import Control.Monad (forM_, join, void, unless, filterM)
 import Control.Monad.Catch (MonadCatch (..))
 import Control.Monad.Extra (whenM)
 import Control.Monad.State

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -10,8 +10,8 @@ import Control.Lens ((^.))
 import Data.Default (Default (..))
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
 
 -- | The 'kind' of the symbol in the LSP sense.
 data SymbolKind = ValueFunction

--- a/src/Curry/LanguageServer/Monad.hs
+++ b/src/Curry/LanguageServer/Monad.hs
@@ -22,7 +22,7 @@ import Data.Default (Default(..))
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 import Language.LSP.Server (LspT, LanguageContextEnv, runLspT)
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 data DirtyModuleHandlers = DirtyModuleHandlers { recompileHandler :: IO ()
                                                , auxiliaryHandler :: IO ()

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -47,7 +47,7 @@ import Curry.LanguageServer.Utils.General
 import Curry.LanguageServer.Utils.Uri (filePathToUri, uriToFilePath)
 import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text as T
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 -- Curry Compiler -> Language Server Protocol
 

--- a/src/Curry/LanguageServer/Utils/General.hs
+++ b/src/Curry/LanguageServer/Utils/General.hs
@@ -50,7 +50,7 @@ import qualified Data.Text as T
 import qualified Data.Trie as TR
 import qualified Data.Map as M
 import qualified Data.Set as S
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 import System.FilePath
 import System.IO.Unsafe (unsafeInterleaveIO)
 import System.Directory

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -14,7 +14,8 @@ import qualified Curry.Base.SpanInfo as CSPI
 import qualified Curry.Syntax as CS
 
 import Control.Applicative (Alternative ((<|>)))
-import Control.Monad.State (State, when, execState, gets, modify)
+import Control.Monad (when)
+import Control.Monad.State (State, execState, gets, modify)
 import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
 import Curry.LanguageServer.Utils.General (rangeElem, joinFst, (<.$>))
 import Curry.LanguageServer.Utils.Syntax

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -28,7 +28,7 @@ import Curry.LanguageServer.Utils.Syntax
 import Curry.LanguageServer.Utils.Sema
     ( HasTypedSpanInfos(typedSpanInfos), TypedSpanInfo )
 import qualified Data.Map as M
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 -- | A collectScope of bound identifiers.
 type Scope a = M.Map CI.Ident (Maybe a)

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -28,7 +28,7 @@ import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range)
 import Curry.LanguageServer.Utils.General (lastSafe, rangeElem)
 import qualified Data.List.NonEmpty as N
 import Data.Maybe (maybeToList)
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 -- | Fetches the element at the given position.
 elementAt :: CSPI.HasSpanInfo e => J.Position -> [e] -> Maybe e

--- a/src/Curry/LanguageServer/Utils/Uri.hs
+++ b/src/Curry/LanguageServer/Utils/Uri.hs
@@ -8,7 +8,7 @@ module Curry.LanguageServer.Utils.Uri
     ) where
 
 import Control.Monad.IO.Class (MonadIO (..))
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 import System.Directory (canonicalizePath)
 
 filePathToUri :: MonadIO m => FilePath -> m J.Uri

--- a/src/Curry/LanguageServer/Utils/VFS.hs
+++ b/src/Curry/LanguageServer/Utils/VFS.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings, MultiWayIf #-}
+module Curry.LanguageServer.Utils.VFS
+    ( PosPrefixInfo (..)
+    , getCompletionPrefix
+    ) where
+
+import Data.Maybe (listToMaybe, fromMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Utf16.Rope.Mixed as Rope
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.VFS as VFS
+import Data.Char (isAlphaNum)
+
+-- Source: https://github.com/haskell/haskell-language-server/blob/a4bcaa31/ghcide/src/Development/IDE/Plugin/Completions/Types.hs#L134-L152
+-- License: Apache 2.0
+
+-- | Describes the line at the current cursor position
+data PosPrefixInfo = PosPrefixInfo
+    { fullLine    :: !T.Text
+      -- ^ The full contents of the line the cursor is at
+
+    , prefixScope :: !T.Text
+      -- ^ If any, the module name that was typed right before the cursor position.
+      --  For example, if the user has typed "Data.Maybe.from", then this property
+      --  will be "Data.Maybe"
+      -- If OverloadedRecordDot is enabled, "Shape.rect.width" will be
+      -- "Shape.rect"
+
+    , prefixText  :: !T.Text
+      -- ^ The word right before the cursor position, after removing the module part.
+      -- For example if the user has typed "Data.Maybe.from",
+      -- then this property will be "from"
+    , cursorPos   :: !J.Position
+      -- ^ The cursor position
+    } deriving (Show,Eq)
+
+-- Source: https://github.com/haskell/haskell-language-server/blob/a4bcaa31/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs#L889-L916
+-- License: Apache 2.0
+
+getCompletionPrefix :: J.Position -> VFS.VirtualFile -> PosPrefixInfo
+getCompletionPrefix pos (VFS.VirtualFile _ _ ropetext) = getCompletionPrefixFromRope pos ropetext
+
+getCompletionPrefixFromRope :: J.Position -> Rope.Rope -> PosPrefixInfo
+getCompletionPrefixFromRope pos@(J.Position l c) ropetext =
+    fromMaybe (PosPrefixInfo "" "" "" pos) $ do -- Maybe monad
+        let headMaybe = listToMaybe
+            lastMaybe = headMaybe . reverse
+
+        -- grab the entire line the cursor is at
+        curLine <- headMaybe $ Rope.lines
+                             $ fst $ Rope.splitAtLine 1 $ snd $ Rope.splitAtLine (fromIntegral l) ropetext
+        let beforePos = T.take (fromIntegral c) curLine
+        -- the word getting typed, after previous space and before cursor
+        curWord <-
+            if | T.null beforePos        -> Just ""
+               | T.last beforePos == ' ' -> Just "" -- don't count abc as the curword in 'abc '
+               | otherwise               -> lastMaybe (T.words beforePos)
+
+        let parts = T.split (=='.')
+                      $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
+        case reverse parts of
+          [] -> Nothing
+          (x:xs) -> do
+            let modParts = reverse $ filter (not .T.null) xs
+                modName = T.intercalate "." modParts
+            return $ PosPrefixInfo { fullLine = curLine, prefixScope = modName, prefixText = x, cursorPos = pos }

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies.
-resolver: lts-20.22
+resolver: lts-22.30
 
 # User packages to be built.
 packages:
@@ -16,11 +16,9 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 extra-deps:
-  - set-extra-1.4.1@sha256:c58aa620704f609f289953e7c1f9c1653fd1498f0984b0f03a3f8f38f7ed5a84
-  - lsp-1.6.0.0
-  - co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
+  - set-extra-1.4.2
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
+    commit: dd346c0c8c72979b8d195d241a8a19258745b134
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,8 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 extra-deps:
+  - lsp-2.7.0.0
+  - lsp-types-2.3.0.0
   - set-extra-1.4.2
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     commit: dd346c0c8c72979b8d195d241a8a19258745b134

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
   - lsp-types-2.3.0.0
   - set-extra-1.4.2
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: dd346c0c8c72979b8d195d241a8a19258745b134
+    commit: bd1750a68e011e56c176491a558885b5268173b5
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,15 +26,15 @@ packages:
   original:
     hackage: set-extra-1.4.2
 - completed:
-    commit: dd346c0c8c72979b8d195d241a8a19258745b134
+    commit: bd1750a68e011e56c176491a558885b5268173b5
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 3b2f6df898d989bf51fe83ee6bd73383e06fe07d1606dd0c0386ad6375c73109
+      sha256: 911cb32d609278b24516b1412aede02daa88f933dc2935399821d418b881ab46
       size: 17097
     version: 2.1.1
   original:
-    commit: dd346c0c8c72979b8d195d241a8a19258745b134
+    commit: bd1750a68e011e56c176491a558885b5268173b5
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,40 +5,26 @@
 
 packages:
 - completed:
-    hackage: set-extra-1.4.1@sha256:c58aa620704f609f289953e7c1f9c1653fd1498f0984b0f03a3f8f38f7ed5a84,533
+    hackage: set-extra-1.4.2@sha256:a1a3899d7ae01cd72dfd4691ae77cf26e8867731dff70e61307f25ddc7fd875d,564
     pantry-tree:
-      sha256: 3b6f94160b9d868f341d841de0e3e9f354ae90b5817b171e2bb68fd67cf2790c
+      sha256: 439f8bd6732a4d250a9e565c5bbcf393f3374e8e346e634494efd62b388fe810
       size: 268
   original:
-    hackage: set-extra-1.4.1@sha256:c58aa620704f609f289953e7c1f9c1653fd1498f0984b0f03a3f8f38f7ed5a84
+    hackage: set-extra-1.4.2
 - completed:
-    hackage: lsp-1.6.0.0@sha256:2b95e406cc85ffa95406ae8ad7d16b82283a6ca2fcb7ea5308a4ef3e6d6e68e6,4397
-    pantry-tree:
-      sha256: 43a82c501ec3074d888f2bf4960e4b447028c1537abbca4cf65e74944604bf62
-      size: 1044
-  original:
-    hackage: lsp-1.6.0.0
-- completed:
-    hackage: co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456,3850
-    pantry-tree:
-      sha256: af9c807ce50a126706bd99983ec71c060a489ab2b914de8dbccf756adccc2a43
-      size: 584
-  original:
-    hackage: co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456
-- completed:
-    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
+    commit: dd346c0c8c72979b8d195d241a8a19258745b134
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 04f6cc0c503b005649d028434ad9c076f24d018dcd8ba8f877c2d7dd75f3f774
+      sha256: 3b2f6df898d989bf51fe83ee6bd73383e06fe07d1606dd0c0386ad6375c73109
       size: 17097
-    version: 2.1.0
+    version: 2.1.1
   original:
-    commit: ec11193bb41e71f3f0ec7ebdd116b9b04d7a6b10
+    commit: dd346c0c8c72979b8d195d241a8a19258745b134
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:
-    sha256: dcf4fc28f12d805480ddbe8eb8c370e11db12f0461d0110a4240af27ac88d725
-    size: 650255
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/22.yaml
-  original: lts-20.22
+    sha256: 795b7a893148a42f09956611a0fa1139293fe6ef934d053468d8e53e3e013390
+    size: 719577
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml
+  original: lts-22.30

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: lsp-2.7.0.0@sha256:2a64b40a69fd9638056ca552d5660203019473061cff1d09dccc0c94e40a275c,3834
+    pantry-tree:
+      sha256: 630a5e18d7783c35a296268959c8d9348ee6dc94540047ea58146b310d8de941
+      size: 1120
+  original:
+    hackage: lsp-2.7.0.0
+- completed:
+    hackage: lsp-types-2.3.0.0@sha256:ca17a686bda5dc7ff04105ca7081dce5a90bcd050c8800a13efd68b7f0901f1c,34215
+    pantry-tree:
+      sha256: 0bf22e394dc804c8cee74d19a7f38021cfd48a15082b39a14753c037f2a64288
+      size: 51996
+  original:
+    hackage: lsp-types-2.3.0.0
+- completed:
     hackage: set-extra-1.4.2@sha256:a1a3899d7ae01cd72dfd4691ae77cf26e8867731dff70e61307f25ddc7fd875d,564
     pantry-tree:
       sha256: 439f8bd6732a4d250a9e565c5bbcf393f3374e8e346e634494efd62b388fe810


### PR DESCRIPTION
This migrates to the LTS 22.30 resolver (i.e. GHC 9.6) and bumps the dependencies correspondingly. The Curry frontend is pinned to an experimental branch that migrates it to the Stack resolver.

As part of the updated Stack snapshot, this also migrates the `lsp` library to 2.7, which includes some larger changes to the LSP types that are now generated from the meta model. The `getCompletionPrefix` function was [removed upstream](https://github.com/haskell/lsp/pull/552), therefore we vendor it (though a slightly newer version taken from `ghcide`).