### PR TITLE
Migrate to record dot syntax

### DIFF
--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, OverloadedStrings, FlexibleContexts #-}
+{-# LANGUAGE LambdaCase, OverloadedStrings, OverloadedRecordDot, FlexibleContexts #-}
 module Curry.LanguageServer.Compiler
     ( CompileAuxiliary (..)
     , CompileState (..)
@@ -113,9 +113,9 @@ compileCurryFileWithDeps cfg aux importPaths outDirPath filePath = (fromMaybe me
     let defOpts = CO.defaultOptions
         cppOpts = CO.optCppOpts defOpts
         cppDefs = M.insert "__PAKCS__" 300 (CO.cppDefinitions cppOpts)
-        opts = CO.defaultOptions { CO.optForce = CFG.cfgForceRecompilation cfg
-                                 , CO.optImportPaths = importPaths ++ CFG.cfgImportPaths cfg
-                                 , CO.optLibraryPaths = CFG.cfgLibraryPaths cfg
+        opts = CO.defaultOptions { CO.optForce = cfg.forceRecompilation
+                                 , CO.optImportPaths = importPaths ++ cfg.importPaths
+                                 , CO.optLibraryPaths = cfg.libraryPaths
                                  , CO.optCppOpts = cppOpts { CO.cppDefinitions = cppDefs }
                                  , CO.optExtensions = nub $ CSE.kielExtensions ++ CO.optExtensions defOpts
                                  , CO.optOriginPragmas = True

--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, OverloadedStrings, OverloadedRecordDot, FlexibleContexts #-}
+{-# LANGUAGE LambdaCase, NoFieldSelectors, OverloadedStrings, OverloadedRecordDot, FlexibleContexts #-}
 module Curry.LanguageServer.Compiler
     ( CompileAuxiliary (..)
     , CompileState (..)
@@ -63,20 +63,20 @@ newtype CompileAuxiliary = CompileAuxiliary
 
 -- | Read/write state used during compilation.
 data CompileState = CompileState
-    { csWarnings :: [CM.Message]
-    , csErrors :: [CM.Message]
+    { warnings :: [CM.Message]
+    , errors :: [CM.Message]
     }
 
 instance Semigroup CompileState where
     x <> y = CompileState
-        { csWarnings = csWarnings x ++ csWarnings y
-        , csErrors = csErrors x ++ csErrors y
+        { warnings = x.warnings ++ y.warnings
+        , errors = x.errors ++ y.errors
         }
 
 instance Monoid CompileState where
     mempty = CompileState
-        { csWarnings = []
-        , csErrors = []
+        { warnings = []
+        , errors = []
         }
 
 -- | A custom monad for compilation state as a CYIO-replacement that doesn't track errors in an ExceptT.
@@ -88,10 +88,10 @@ runCMT cm aux = flip runReaderT aux . flip runStateT mempty . runMaybeT $ cm
 catchCYIO :: MonadIO m => CYIO a -> CMT m (Maybe a)
 catchCYIO cyio = liftIO (runCYIO cyio) >>= \case
     Left es       -> do
-        modify $ \s -> s { csErrors = csErrors s ++ es }
+        modify $ \s -> s { errors = s.errors ++ es }
         return Nothing
     Right (x, ws) -> do
-        modify $ \s -> s { csWarnings = csWarnings s ++ ws }
+        modify $ \s -> s { warnings = s.warnings ++ ws }
         return $ Just x
 
 liftToCM :: Monad m => m a -> CMT m a
@@ -170,7 +170,7 @@ compileCurryModule opts outDirPath m fp = do
 loadAndCheckCurryModule :: MonadIO m => CO.Options -> CI.ModuleIdent -> FilePath -> CMT m (CE.CompEnv ModuleAST)
 loadAndCheckCurryModule opts m fp = do
     -- Read source file (possibly from VFS)
-    fl <- asks fileLoader
+    fl <- asks (.fileLoader)
     src <- liftIO $ fl fp
     -- Load and check module
     loaded <- liftCYIO $ loadCurryModule opts m src fp
@@ -231,7 +231,7 @@ parseCurryModule opts _ src fp = do
     return (lexed, ast)
 
 failedCompilation :: String -> (CompileOutput, CompileState)
-failedCompilation msg = (mempty, mempty { csErrors = [makeFailMessage msg] })
+failedCompilation msg = (mempty, mempty { errors = [makeFailMessage msg] })
 
 makeFailMessage :: String -> CM.Message
 makeFailMessage = CM.message . PP.text

--- a/src/Curry/LanguageServer/Config.hs
+++ b/src/Curry/LanguageServer/Config.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, OverloadedStrings, TypeApplications #-}
+{-# LANGUAGE NoFieldSelectors, OverloadedRecordDot, RecordWildCards, OverloadedStrings, TypeApplications #-}
 module Curry.LanguageServer.Config
     ( Config (..)
     , LogLevel (..)
@@ -18,49 +18,49 @@ import Data.Aeson
 import Data.Default (Default(..))
 import qualified Data.Text as T
 
-newtype LogLevel = LogLevel { llSeverity :: Severity }
+newtype LogLevel = LogLevel { severity :: Severity }
     deriving (Show, Eq)
 
-data Config = Config { cfgForceRecompilation :: Bool
-                     , cfgImportPaths :: [FilePath]
-                     , cfgLibraryPaths :: [FilePath]
-                     , cfgLogLevel :: LogLevel
-                     , cfgCurryPath :: String
-                     , cfgUseSnippetCompletions :: Bool
+data Config = Config { forceRecompilation :: Bool
+                     , importPaths :: [FilePath]
+                     , libraryPaths :: [FilePath]
+                     , logLevel :: LogLevel
+                     , curryPath :: String
+                     , useSnippetCompletions :: Bool
                      }
     deriving (Show, Eq)
 
 instance Default Config where
-    def = Config { cfgForceRecompilation = False
-                 , cfgImportPaths = []
-                 , cfgLibraryPaths = []
-                 , cfgLogLevel = LogLevel Info
-                 , cfgCurryPath = "pakcs"
-                 , cfgUseSnippetCompletions = False
+    def = Config { forceRecompilation = False
+                 , importPaths = []
+                 , libraryPaths = []
+                 , logLevel = LogLevel Info
+                 , curryPath = "pakcs"
+                 , useSnippetCompletions = False
                  }
 
 instance FromJSON Config where
     parseJSON = withObject "Config" $ \o -> do
         c <- o .: "curry"
         l <- c .: "languageServer"
-        cfgForceRecompilation    <- l .:? "forceRecompilation"    .!= cfgForceRecompilation def
-        cfgImportPaths           <- l .:? "importPaths"           .!= cfgImportPaths def
-        cfgLibraryPaths          <- l .:? "libraryPaths"          .!= cfgLibraryPaths def
-        cfgLogLevel              <- l .:? "logLevel"              .!= cfgLogLevel def
-        cfgCurryPath             <- l .:? "curryPath"             .!= cfgCurryPath def
-        cfgUseSnippetCompletions <- l .:? "useSnippetCompletions" .!= cfgUseSnippetCompletions def
+        forceRecompilation    <- l .:? "forceRecompilation"    .!= (def @Config).forceRecompilation
+        importPaths           <- l .:? "importPaths"           .!= (def @Config).importPaths
+        libraryPaths          <- l .:? "libraryPaths"          .!= (def @Config).libraryPaths
+        logLevel              <- l .:? "logLevel"              .!= (def @Config).logLevel
+        curryPath             <- l .:? "curryPath"             .!= (def @Config).curryPath
+        useSnippetCompletions <- l .:? "useSnippetCompletions" .!= (def @Config).useSnippetCompletions
         return Config {..}
 
 instance ToJSON Config where
     toJSON Config {..} = object
         ["curry" .= object
             [ "languageServer" .= object
-                [ "forceRecompilation"    .= cfgForceRecompilation
-                , "importPaths"           .= cfgImportPaths
-                , "libraryPaths"          .= cfgLibraryPaths
-                , "logLevel"              .= cfgLogLevel
-                , "curryPath"             .= cfgCurryPath
-                , "useSnippetCompletions" .= cfgUseSnippetCompletions
+                [ "forceRecompilation"    .= forceRecompilation
+                , "importPaths"           .= importPaths
+                , "libraryPaths"          .= libraryPaths
+                , "logLevel"              .= logLevel
+                , "curryPath"             .= curryPath
+                , "useSnippetCompletions" .= useSnippetCompletions
                 ]
             ]
         ]

--- a/src/Curry/LanguageServer/Handlers/Diagnostics.hs
+++ b/src/Curry/LanguageServer/Handlers/Diagnostics.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot #-}
 module Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics, fetchDiagnostics) where
 
 import Control.Monad (unless)
@@ -30,8 +30,8 @@ emitDiagnostics normUri entry = do
 
 fetchDiagnostics :: (MonadIO m, MonadLsp CFG.Config m) => J.NormalizedUri -> ModuleStoreEntry -> m [J.Diagnostic]
 fetchDiagnostics normUri entry = do
-    let warnings = map (curryMsg2Diagnostic J.DsWarning) $ mseWarningMessages entry
-        errors = map (curryMsg2Diagnostic J.DsError) $ mseErrorMessages entry
+    let warnings = map (curryMsg2Diagnostic J.DsWarning) entry.warningMessages
+        errors = map (curryMsg2Diagnostic J.DsError) entry.errorMessages
         diags = warnings ++ errors
         name = maybe "?" takeBaseName $ normalizedUriToFilePath normUri
     

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings, OverloadedRecordDot #-}
 module Curry.LanguageServer.Handlers.TextDocument.CodeAction (codeActionHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -39,7 +39,7 @@ codeActionHandler = S.requestHandler J.STextDocumentCodeAction $ \req responder 
 
 fetchCodeActions :: (MonadIO m, MonadLsp CFG.Config m) => J.Range -> I.ModuleStoreEntry -> m [J.CodeAction]
 fetchCodeActions range entry = do
-    actions <- maybe (pure []) (codeActions range) $ I.mseModuleAST entry
+    actions <- maybe (pure []) (codeActions range) entry.moduleAST
     debugM $ "Found " <> T.pack (show (length actions)) <> " code action(s)"
     return actions
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, OverloadedStrings, OverloadedRecordDot #-}
 module Curry.LanguageServer.Handlers.TextDocument.CodeLens (codeLensHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -40,7 +40,7 @@ codeLensHandler = S.requestHandler J.STextDocumentCodeLens $ \req responder -> d
 
 fetchCodeLenses :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.CodeLens]
 fetchCodeLenses entry = do
-    lenses <- maybe (pure []) codeLenses $ I.mseModuleAST entry
+    lenses <- maybe (pure []) codeLenses entry.moduleAST
     infoM $ "Found " <> T.pack (show (length lenses)) <> " code lens(es)"
     return lenses
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -101,7 +101,7 @@ importCompletions opts store query = do
 
 generalCompletions :: (MonadIO m, MonadLsp CFG.Config m) => CompletionOptions -> I.ModuleStoreEntry -> I.IndexStore -> VFS.PosPrefixInfo -> m [J.CompletionItem]
 generalCompletions opts entry store query = do
-    let localIdentifiers   = join <$> maybe M.empty (`findScopeAtPos` VFS.cursorPos query) (I.mseModuleAST entry)
+    let localIdentifiers   = join <$> maybe M.empty (`findScopeAtPos` VFS.cursorPos query) entry.moduleAST
         localIdentifiers'  = M.fromList $ map (first ppToText) $ M.toList localIdentifiers
         localCompletions   = toMatchingCompletions opts query $ uncurry Local <$> M.toList localIdentifiers'
         symbols            = filter (flip M.notMember localIdentifiers' . I.sIdent) $ nubOrdOn I.sQualIdent
@@ -139,7 +139,7 @@ newtype CompletionOptions = CompletionOptions
 -- | Turns an index symbol into completion symbols by analyzing the module's imports.
 toCompletionSymbols :: I.ModuleStoreEntry -> I.Symbol -> [CompletionSymbol]
 toCompletionSymbols entry s = do
-    CS.Module _ _ _ mid _ imps _ <- maybeToList $ I.mseModuleAST entry
+    CS.Module _ _ _ mid _ imps _ <- maybeToList entry.moduleAST
     let pre = "Prelude"
         impNames = S.fromList [ppToText mid' | CS.ImportDecl _ mid' _ _ _ <- imps]
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -5,7 +5,7 @@ module Curry.LanguageServer.Handlers.TextDocument.Completion (completionHandler)
 import qualified Curry.Syntax as CS
 import qualified Base.Types as CT
 
-import Control.Lens ((^.), (.~))
+import Control.Lens ((^.), (?~))
 import Control.Monad (join, guard)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (lift)
@@ -281,7 +281,7 @@ instance ToCompletionItems T.Text where
               edits = Nothing
 
 instance ToCompletionItems a => ToCompletionItems (Tagged a) where
-    toCompletionItems opts query (Tagged tags x) = (J.tags .~ Just (J.List tags)) <$> toCompletionItems opts query x
+    toCompletionItems opts query (Tagged tags x) = (J.tags ?~ J.List tags) <$> toCompletionItems opts query x
 
 -- | Creates a snippet with VSCode-style syntax.
 makeSnippet :: T.Text -> [T.Text] -> T.Text

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, FlexibleInstances, MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings, OverloadedRecordDot, FlexibleContexts, FlexibleInstances, MultiWayIf #-}
 module Curry.LanguageServer.Handlers.TextDocument.Completion (completionHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -48,7 +48,7 @@ completionHandler = S.requestHandler J.STextDocumentCompletion $ \req responder 
         query <- MaybeT $ VFS.getCompletionPrefix pos vfile
 
         let opts = CompletionOptions
-                { cmoUseSnippets = CFG.cfgUseSnippetCompletions cfg && fromMaybe False (do
+                { cmoUseSnippets = cfg.useSnippetCompletions && fromMaybe False (do
                     docCapabilities <- capabilities ^. J.textDocument
                     cmCapabilities <- docCapabilities ^. J.completion
                     ciCapabilities <- cmCapabilities ^. J.completionItem

--- a/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/DocumentSymbol.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot #-}
 module Curry.LanguageServer.Handlers.TextDocument.DocumentSymbol (documentSymbolHandler) where
 
 import Control.Monad.IO.Class (MonadIO (..))
@@ -30,6 +30,6 @@ documentSymbolHandler = S.requestHandler J.STextDocumentDocumentSymbol $ \req re
 
 fetchDocumentSymbols :: (MonadIO m, MonadLsp CFG.Config m) => I.ModuleStoreEntry -> m [J.DocumentSymbol]
 fetchDocumentSymbols entry = do
-    let symbols = maybe [] documentSymbols $ I.mseModuleAST entry
+    let symbols = maybe [] documentSymbols entry.moduleAST
     debugM $ "Found document symbols " <> T.pack (show symbols)
     return symbols

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot, ViewPatterns #-}
 module Curry.LanguageServer.Handlers.TextDocument.Hover (hoverHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -41,7 +41,7 @@ hoverHandler = S.requestHandler J.STextDocumentHover $ \req responder -> do
 
 fetchHover :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> J.Position -> m (Maybe J.Hover)
 fetchHover store entry pos = runMaybeT $ do
-    ast <- liftMaybe $ I.mseModuleAST entry
+    ast <- liftMaybe entry.moduleAST
     hover <- liftMaybe $ qualIdentHover store ast pos <|> typedSpanInfoHover ast pos
     lift $ infoM $ "Found hover: " <> previewHover hover
     return hover

--- a/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/SignatureHelp.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, MonadComprehensions #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, OverloadedRecordDot, MonadComprehensions #-}
 module Curry.LanguageServer.Handlers.TextDocument.SignatureHelp (signatureHelpHandler) where
 
 -- Curry Compiler Libraries + Dependencies
@@ -53,7 +53,7 @@ signatureHelpHandler = S.requestHandler J.STextDocumentSignatureHelp $ \req resp
 
 fetchSignatureHelp :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> VFS.VirtualFile -> J.Position -> m (Maybe J.SignatureHelp)
 fetchSignatureHelp store entry vfile pos@(J.Position l c) = runMaybeT $ do
-    ast <- liftMaybe $ I.mseModuleAST entry
+    ast <- liftMaybe entry.moduleAST
     let line = VFS.rangeLinesFromVfs vfile $ J.Range (J.Position l 0) (J.Position (l + 1) 0)
         c'   = snapToLastTokenEnd (T.unpack line) c
         pos' = J.Position l c'

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -285,8 +285,8 @@ recompileFile i total cfg fl importPaths dirPath filePath = void $ do
     -- Ignore parses from interface files, only consider source files for now
     asts <- mapM (\(fp, mdl) -> (, mdl) <$> filePathToNormalizedUri fp) $ filter ((".curry" `T.isSuffixOf`) . T.pack . fst) co
 
-    warns  <- groupIntoMapByM msgNormUri $ C.csWarnings cs
-    errors <- groupIntoMapByM msgNormUri $ C.csErrors cs
+    warns  <- groupIntoMapByM msgNormUri cs.warnings
+    errors <- groupIntoMapByM msgNormUri cs.errors
 
     debugM $ "Recompiled module paths: " <> T.pack (show (fst <$> asts))
 

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 module Curry.LanguageServer.Index.Store
     ( ModuleStoreEntry (..)
     , IndexStore (..)
@@ -184,7 +185,7 @@ findCurrySourcesInWorkspace cfg dirPath = do
 -- | Finds the Curry source files in a (project) directory.
 findCurrySourcesInProject :: (MonadIO m, MonadLsp CFG.Config m) => CFG.Config -> FilePath -> m [CurrySourceFile]
 findCurrySourcesInProject cfg dirPath = do
-    let curryPath = CFG.cfgCurryPath cfg
+    let curryPath = cfg.curryPath
         cpmPath = curryPath ++ " cypm"
         libPath binPath = takeDirectory (takeDirectory binPath) </> "lib"
 

--- a/src/Curry/LanguageServer/Utils/Logging.hs
+++ b/src/Curry/LanguageServer/Utils/Logging.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings, OverloadedRecordDot, FlexibleContexts #-}
 module Curry.LanguageServer.Utils.Logging
     ( logAt, showAt
     , errorM, warnM, infoM, debugM
@@ -6,7 +6,7 @@ module Curry.LanguageServer.Utils.Logging
 
 import Colog.Core (Severity (..), WithSeverity (..), (<&))
 import Control.Monad (when)
-import Curry.LanguageServer.Config (Config (cfgLogLevel), LogLevel (llSeverity))
+import Curry.LanguageServer.Config (Config (..), LogLevel (..))
 import qualified Data.Text as T
 import Language.LSP.Logging (logToLogMessage, logToShowMessage)
 import Language.LSP.Server (MonadLsp, getConfig)
@@ -15,7 +15,7 @@ import Language.LSP.Server (MonadLsp, getConfig)
 logAt :: MonadLsp Config m => Severity -> T.Text -> m ()
 logAt sev msg = do
     cfg <- getConfig
-    when (sev >= llSeverity (cfgLogLevel cfg)) $
+    when (sev >= cfg.logLevel.severity) $
         logToLogMessage <& WithSeverity msg sev
 
 -- | Presents a log message in a notification to the user (window/showMessage).


### PR DESCRIPTION
### Fixes #58 

This migrates the codebase to the new record dot syntax, which was added in recent GHC versions.