### PR TITLE
Refactor bindist script to generate gzipped tarballs on Linux and macOS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
       shell: bash
-      run: gh release upload "${{ needs.release.outputs.tag }}" bindists/*
+      run: gh release upload "${{ needs.release.outputs.tag }}" bindists/*.{tar.gz,zip}

--- a/scripts/make-bindist
+++ b/scripts/make-bindist
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import argparse
 import platform
+import shutil
 import subprocess
 import zipfile
 
@@ -11,25 +12,23 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 
 def main():
     parser = argparse.ArgumentParser(description='Creates a binary distribution of the language server')
-    parser.add_argument('-o', '--output', type=Path, default=ROOT_DIR / 'bindists' / f'curry-language-server-{platform.machine().lower()}-{platform.system().lower()}.zip', help='The name of the output zip.')
+    parser.add_argument('-f', '--format', type=str, default='zip' if platform.system() == 'Windows' else 'gztar', help='The format of the output archive.')
+    parser.add_argument('-o', '--output', type=Path, default=ROOT_DIR / 'bindists' / f'curry-language-server-{platform.machine().lower()}-{platform.system().lower()}', help='The name of the output archive.')
 
     args = parser.parse_args()
-    bin_dir = 'bin'
-    output = args.output
+    format: str = args.format
+    output: Path = args.output
+
+    output.mkdir(parents=True, exist_ok=True)
     
     print('==> Building...')
-    subprocess.run(['stack', 'install', '--local-bin-path', bin_dir], check=True, cwd=ROOT_DIR)
+    subprocess.run(['stack', 'install', '--local-bin-path', output / 'bin'], check=True, cwd=ROOT_DIR)
+
+    print('==> Packaging...')
+    shutil.copy('LICENSE', output)
 
     print('==> Archiving...')
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(output, mode='w') as zip:
-        for f in [bin_dir, 'LICENSE']:
-            path = ROOT_DIR / f
-            if path.is_dir():
-                for child in path.rglob('*'):
-                    zip.write(child, child.relative_to(ROOT_DIR))
-            else:
-                zip.write(path, path.relative_to(ROOT_DIR))
+    shutil.make_archive(output, format, output.parent, output.name)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This refactors the bindist script and updates it to use `.tar.gz` archives on Linux and macOS, to avoid trouble with maintaining the executable permission on the binary.