### PR TITLE
Move initialization into `doInitialize` and report progress

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ import qualified Language.LSP.Server as S
 import qualified Language.LSP.Protocol.Types as J
 import qualified Curry.LanguageServer.Config as CFG
 import Curry.LanguageServer.Handlers
+import Curry.LanguageServer.Handlers.Initialize (initializeHandler)
 import Curry.LanguageServer.Handlers.Workspace.Command (commands)
 import Curry.LanguageServer.Monad (runLSM, newLSStateVar)
 import System.Exit (ExitCode(ExitFailure), exitSuccess, exitWith)
@@ -32,7 +33,7 @@ runLanguageServer = do
         -- TODO: Handle configuration changes (ideally from here, not in the didChangeConfiguration handler)
         -- See https://hackage.haskell.org/package/lsp-2.7.0.0/docs/Language-LSP-Server.html#t:ServerDefinition
         , S.onConfigChange = const $ pure ()
-        , S.doInitialize = const . pure . Right
+        , S.doInitialize = \env req -> runLSM (initializeHandler req) state env >> return (Right env)
         , S.staticHandlers = handlers
         , S.interpretHandler = \env -> S.Iso (\lsm -> runLSM lsm state env) liftIO
         , S.options = S.defaultOptions

--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -35,7 +35,7 @@ library
       Curry.LanguageServer.Handlers
       Curry.LanguageServer.Handlers.Cancel
       Curry.LanguageServer.Handlers.Diagnostics
-      Curry.LanguageServer.Handlers.Initialized
+      Curry.LanguageServer.Handlers.Initialize
       Curry.LanguageServer.Handlers.TextDocument.CodeAction
       Curry.LanguageServer.Handlers.TextDocument.CodeLens
       Curry.LanguageServer.Handlers.TextDocument.Completion

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -9,7 +9,7 @@ import Curry.LanguageServer.Handlers.TextDocument.DocumentSymbol (documentSymbol
 import Curry.LanguageServer.Handlers.TextDocument.Notifications (didOpenHandler, didChangeHandler, didSaveHandler, didCloseHandler)
 import Curry.LanguageServer.Handlers.TextDocument.Hover (hoverHandler)
 import Curry.LanguageServer.Handlers.TextDocument.SignatureHelp (signatureHelpHandler)
-import Curry.LanguageServer.Handlers.Initialized (initializedHandler)
+import Curry.LanguageServer.Handlers.Initialize (initializedHandler)
 import Curry.LanguageServer.Handlers.Workspace.Command (executeCommandHandler)
 import Curry.LanguageServer.Handlers.Workspace.Notifications (didChangeConfigurationHandler)
 import Curry.LanguageServer.Handlers.Workspace.Symbol (workspaceSymbolHandler)

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -1,6 +1,7 @@
 module Curry.LanguageServer.Handlers (handlers) where
 
 import Curry.LanguageServer.Handlers.Cancel (cancelHandler)
+import Curry.LanguageServer.Handlers.Initialize (initializedHandler)
 import Curry.LanguageServer.Handlers.TextDocument.CodeAction (codeActionHandler)
 import Curry.LanguageServer.Handlers.TextDocument.CodeLens (codeLensHandler)
 import Curry.LanguageServer.Handlers.TextDocument.Completion (completionHandler)
@@ -29,6 +30,7 @@ handlers _caps = mconcat
     , codeLensHandler
     , signatureHelpHandler
       -- Notification handlers
+    , initializedHandler
     , didOpenHandler
     , didChangeHandler
     , didSaveHandler

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -9,7 +9,6 @@ import Curry.LanguageServer.Handlers.TextDocument.DocumentSymbol (documentSymbol
 import Curry.LanguageServer.Handlers.TextDocument.Notifications (didOpenHandler, didChangeHandler, didSaveHandler, didCloseHandler)
 import Curry.LanguageServer.Handlers.TextDocument.Hover (hoverHandler)
 import Curry.LanguageServer.Handlers.TextDocument.SignatureHelp (signatureHelpHandler)
-import Curry.LanguageServer.Handlers.Initialize (initializedHandler)
 import Curry.LanguageServer.Handlers.Workspace.Command (executeCommandHandler)
 import Curry.LanguageServer.Handlers.Workspace.Notifications (didChangeConfigurationHandler)
 import Curry.LanguageServer.Handlers.Workspace.Symbol (workspaceSymbolHandler)
@@ -30,7 +29,6 @@ handlers _caps = mconcat
     , codeLensHandler
     , signatureHelpHandler
       -- Notification handlers
-    , initializedHandler
     , didOpenHandler
     , didChangeHandler
     , didSaveHandler

--- a/src/Curry/LanguageServer/Handlers/Initialize.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialize.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds, OverloadedStrings #-}
 module Curry.LanguageServer.Handlers.Initialize (initializeHandler) where
 
-import qualified Curry.LanguageServer.Config as CFG
+import Control.Lens ((^.))
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)
 import Curry.LanguageServer.Utils.Logging (infoM)
@@ -9,19 +9,22 @@ import qualified Curry.LanguageServer.Index.Store as I
 import Curry.LanguageServer.Monad (LSM)
 import Data.Maybe (maybeToList, fromMaybe)
 import qualified Data.Text as T
+import qualified Language.LSP.Protocol.Lens as J
 import qualified Language.LSP.Protocol.Types as J
 import qualified Language.LSP.Protocol.Message as J
 import qualified Language.LSP.Server as S
 
 initializeHandler :: J.TMessage J.Method_Initialize -> LSM ()
 initializeHandler req = do
-    infoM "Building index store..."
-    workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
-    let folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri
-        folders = maybeToList . folderToPath =<< workspaceFolders
-    mapM_ addDirToIndexStore folders
-    count <- I.getModuleCount
-    infoM $ "Indexed " <> T.pack (show count) <> " files"
+    let token = req ^. J.params . J.workDoneToken
+    S.withIndefiniteProgress "Initializing Curry..." token S.NotCancellable $ \updater -> do
+        infoM "Building index store..."
+        workspaceFolders <- fromMaybe [] <$> S.getWorkspaceFolders
+        let folderToPath (J.WorkspaceFolder uri _) = J.uriToFilePath uri
+            folders = maybeToList . folderToPath =<< workspaceFolders
+        mapM_ addDirToIndexStore folders
+        count <- I.getModuleCount
+        infoM $ "Indexed " <> T.pack (show count) <> " files"
 
 -- | Indexes a workspace folder recursively.
 addDirToIndexStore :: FilePath -> LSM ()

--- a/src/Curry/LanguageServer/Handlers/Initialize.hs
+++ b/src/Curry/LanguageServer/Handlers/Initialize.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Curry.LanguageServer.Handlers.Initialized (initializedHandler) where
+module Curry.LanguageServer.Handlers.Initialize (initializedHandler) where
 
 import Curry.LanguageServer.FileLoader (fileLoader)
 import Curry.LanguageServer.Handlers.Diagnostics (emitDiagnostics)


### PR DESCRIPTION
### Supersedes #24 

Performing our initialization (indexing and compiling all modules) before responding to the `initialize` request, instead of in the `initialized` notification, seems to be a cleaner way of handling required initialization, since language features like go-to-definition will be fully disabled instead of hanging. Additionally, the client can provide us with a progress token to report progress with.

Since we cannot report diagnostics before responding to `initialize`, we leave that in the `initialized` notification handler.