### PR TITLE
Update frontend to add support for MPTC and functional dependencies

### DIFF
--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -68,19 +68,19 @@ library
   ghc-options: -Wall
   build-depends:
       Glob ==0.10.*
-    , aeson >=2.0 && <2.2
+    , aeson ==2.2.*
     , async ==2.2.*
     , base >=4.16 && <4.19
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
-    , containers ==0.6.*
+    , containers >=0.6 && <0.8
     , curry-frontend
     , data-default ==0.7.*
     , directory ==1.3.*
     , either >=5.0 && <6
     , exceptions ==0.10.*
-    , extra ==1.7.*
+    , extra >=1.7 && <1.9
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
     , lsp ==2.7.*
@@ -90,7 +90,7 @@ library
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==2.0.*
+    , text >=2.0 && <2.2
     , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
@@ -105,20 +105,20 @@ executable curry-language-server
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
       Glob ==0.10.*
-    , aeson >=2.0 && <2.2
+    , aeson ==2.2.*
     , async ==2.2.*
     , base >=4.16 && <4.19
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
-    , containers ==0.6.*
+    , containers >=0.6 && <0.8
     , curry-frontend
     , curry-language-server
     , data-default ==0.7.*
     , directory ==1.3.*
     , either >=5.0 && <6
     , exceptions ==0.10.*
-    , extra ==1.7.*
+    , extra >=1.7 && <1.9
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
     , lsp ==2.7.*
@@ -128,7 +128,7 @@ executable curry-language-server
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==2.0.*
+    , text >=2.0 && <2.2
     , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*
@@ -144,20 +144,20 @@ test-suite curry-language-server-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Glob ==0.10.*
-    , aeson >=2.0 && <2.2
+    , aeson ==2.2.*
     , async ==2.2.*
     , base >=4.16 && <4.19
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , bytestring-trie ==0.2.*
     , co-log-core ==0.3.*
-    , containers ==0.6.*
+    , containers >=0.6 && <0.8
     , curry-frontend
     , curry-language-server
     , data-default ==0.7.*
     , directory ==1.3.*
     , either >=5.0 && <6
     , exceptions ==0.10.*
-    , extra ==1.7.*
+    , extra >=1.7 && <1.9
     , filepath ==1.4.*
     , lens >=5.1 && <5.3
     , lsp ==2.7.*
@@ -167,7 +167,7 @@ test-suite curry-language-server-test
     , process >=1.6 && <2
     , sorted-list ==0.2.*
     , stm ==2.5.*
-    , text ==2.0.*
+    , text >=2.0 && <2.2
     , text-rope ==0.2.*
     , transformers >=0.5 && <0.7
     , unliftio-core ==0.2.*

--- a/package.yaml
+++ b/package.yaml
@@ -14,17 +14,17 @@ extra-source-files:
 
 dependencies:
   - base            >= 4.16 && < 4.19
-  - aeson           >= 2.0  && < 2.2
+  - aeson           >= 2.2  && < 2.3
   - async           >= 2.2  && < 2.3
-  - containers      >= 0.6  && < 0.7
+  - containers      >= 0.6  && < 0.8
   - data-default    >= 0.7  && < 0.8
-  - extra           >= 1.7  && < 1.8
+  - extra           >= 1.7  && < 1.9
   - either          >= 5.0  && < 6
   - mtl             >= 2.2  && < 2.4
   - transformers    >= 0.5  && < 0.7
   - exceptions      >= 0.10 && < 0.11
   - stm             >= 2.5  && < 2.6
-  - text            >= 2.0  && < 2.1
+  - text            >= 2.0  && < 2.2
   - text-rope       >= 0.2  && < 0.3
   - lens            >= 5.1  && < 5.3
   - co-log-core     >= 0.3  && < 0.4
@@ -34,7 +34,7 @@ dependencies:
   - sorted-list     >= 0.2  && < 0.3
   - lsp             >= 2.7  && < 2.8
   - unliftio-core   >= 0.2  && < 0.3
-  - bytestring      >= 0.11 && < 0.12
+  - bytestring      >= 0.11 && < 0.13
   - bytestring-trie >= 0.2  && < 0.3
   - process         >= 1.6  && < 2
   - parsec          >= 3.1  && < 4

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -5,8 +5,6 @@ module Curry.LanguageServer.Index.Convert
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
-import qualified Base.CurryKinds as CKS
-import qualified Base.CurryTypes as CTS
 import qualified Base.TopEnv as CTE
 import qualified Base.Types as CT
 import qualified Base.Kinds as CK
@@ -74,7 +72,7 @@ makeValueSymbol k q t = do
         , printedType = Just $ ppToText t
         -- We explicitly perform the Type -> TypeExpr conversion here since
         -- the Pretty Type instance ignores the precedence.
-        , printedArgumentTypes = ppToTextPrec 2 . CTS.fromType CI.identSupply <$> CT.arrowArgs (CT.rawType t)
+        , printedArgumentTypes = ppToTextPrec 2 . CT.fromType CI.identSupply <$> CT.arrowArgs (CT.rawType t)
         , printedResultType = Just $ ppToText $ CT.arrowBase (CT.rawType t)
         , arrowArity = Just $ CT.arrowArity $ CT.rawType t
         , location = loc
@@ -90,7 +88,7 @@ makeTypeSymbol k q k' = do
         , printedType = Just $ ppToText k'
         -- We explicitly perform the Kind conversion here since
         -- the Pretty Kind instance ignores the precedence.
-        , printedArgumentTypes = ppToTextPrec 2 . CKS.fromKind <$> CK.kindArgs k'
+        , printedArgumentTypes = ppToTextPrec 2 . CK.fromKind <$> CK.kindArgs k'
         , printedResultType = Just $ ppToText $ kindBase k'
         , arrowArity = Just $ CK.kindArity k'
         , location = loc

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -37,7 +37,6 @@ import qualified Curry.Base.Pretty as CPP
 import qualified Curry.Base.Span as CSP
 import qualified Curry.Base.SpanInfo as CSPI
 import qualified Curry.Syntax as CS
-import qualified Base.CurryTypes as CCT
 import qualified Base.Types as CT
 import qualified Text.PrettyPrint as PP
 
@@ -174,10 +173,10 @@ ppToText :: CPP.Pretty p => p -> T.Text
 ppToText = T.pack . ppToString
 
 ppTypeSchemeToText :: CI.ModuleIdent -> CT.TypeScheme -> T.Text
-ppTypeSchemeToText mid = T.pack . PP.render . CCT.ppTypeScheme mid
+ppTypeSchemeToText mid = T.pack . PP.render . CT.ppTypeScheme mid
 
 ppPredTypeToText :: CI.ModuleIdent -> CT.PredType -> T.Text
-ppPredTypeToText mid = T.pack . PP.render . CCT.ppPredType mid
+ppPredTypeToText mid = T.pack . PP.render . CT.ppPredType mid
 
 ppPatternToName :: CS.Pattern a -> T.Text
 ppPatternToName pat = case pat of

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -233,7 +233,7 @@ instance HasDocumentSymbols (CS.Decl a) where
                   symKind = if patArity pat > 0 then J.SymbolKind_Function
                                                 else J.SymbolKind_Constant
                   childs = documentSymbols rhs
-        CS.ClassDecl _ _ _ ident _ decls -> [makeDocumentSymbol name symKind range $ Just childs]
+        CS.ClassDecl _ _ _ ident _ _ decls -> [makeDocumentSymbol name symKind range $ Just childs]
             where name = ppToText ident
                   symKind = J.SymbolKind_Interface
                   childs = documentSymbols =<< decls
@@ -252,7 +252,7 @@ instance HasDocumentSymbols (CS.Decl a) where
                   CS.FunctionPattern _ _ _ ps -> length ps
                   _                           -> 0
               eqsArity :: [CS.Equation a] -> Int
-              eqsArity eqs = maybe 1 (\(CS.Equation _ lhs _) -> lhsArity lhs) $ listToMaybe eqs
+              eqsArity eqs = maybe 1 (\(CS.Equation _ _ lhs _) -> lhsArity lhs) $ listToMaybe eqs
               range = currySpanInfo2Range $ CSPI.getSpanInfo decl
 
 instance HasDocumentSymbols (CS.Var a) where
@@ -267,7 +267,7 @@ instance HasDocumentSymbols CS.ConstrDecl where
         where range = currySpanInfo2Range $ CSPI.getSpanInfo decl
 
 instance HasDocumentSymbols (CS.Equation a) where
-    documentSymbols (CS.Equation _ _ rhs) = documentSymbols rhs
+    documentSymbols (CS.Equation _ _ _ rhs) = documentSymbols rhs
 
 instance HasDocumentSymbols (CS.Rhs a) where
     documentSymbols rhs = case rhs of

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -138,7 +138,7 @@ instance CollectScope (CS.Pattern a) a where
 
 
 instance CollectScope (CS.Equation a) a where
-    collectScope eqn@(CS.Equation _ lhs rhs) = withScope $ collectScope lhs >> collectScope rhs >> updateEnvs eqn
+    collectScope eqn@(CS.Equation _ _ lhs rhs) = withScope $ collectScope lhs >> collectScope rhs >> updateEnvs eqn
 
 instance CollectScope (CS.Lhs a) a where
     collectScope lhs = (>> updateEnvs lhs) $ case lhs of

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -118,7 +118,7 @@ instance CollectScope (LocalDecl a) a where
         CS.FunctionDecl _ t i eqs    -> bind i (Just t) >> collectScope eqs
         CS.PatternDecl _ p rhs       -> collectScope p >> collectScope rhs
         CS.InstanceDecl _ _ _ _ _ ds -> collectScope $ TopDecl <$> ds
-        CS.ClassDecl _ _ _ _ _ ds    -> collectScope $ TopDecl <$> ds
+        CS.ClassDecl _ _ _ _ _ _ ds  -> collectScope $ TopDecl <$> ds
         _                            -> return ()
 
 instance CollectScope (CS.Pattern a) a where

--- a/src/Curry/LanguageServer/Utils/Sema.hs
+++ b/src/Curry/LanguageServer/Utils/Sema.hs
@@ -47,7 +47,7 @@ instance HasTypedSpanInfos (CS.Decl a) a where
         _                            -> []
 
 instance HasTypedSpanInfos (CS.Equation a) a where
-    typedSpanInfos (CS.Equation _ lhs rhs) = typedSpanInfos lhs ++ typedSpanInfos rhs
+    typedSpanInfos (CS.Equation _ _ lhs rhs) = typedSpanInfos lhs ++ typedSpanInfos rhs
 
 instance HasTypedSpanInfos (CS.Var a) a where
     typedSpanInfos (CS.Var t i) = [TypedSpanInfo txt t $ CSPI.getSpanInfo i]

--- a/src/Curry/LanguageServer/Utils/Sema.hs
+++ b/src/Curry/LanguageServer/Utils/Sema.hs
@@ -42,7 +42,7 @@ instance HasTypedSpanInfos (CS.Decl a) a where
         CS.ExternalDecl _ vs         -> typedSpanInfos vs
         CS.PatternDecl _ p rhs       -> typedSpanInfos p ++ typedSpanInfos rhs
         CS.FreeDecl _ vs             -> typedSpanInfos vs
-        CS.ClassDecl _ _ _ _ _ ds    -> typedSpanInfos ds
+        CS.ClassDecl _ _ _ _ _ _ ds  -> typedSpanInfos ds
         CS.InstanceDecl _ _ _ _ _ ds -> typedSpanInfos ds
         _                            -> []
 

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -76,7 +76,7 @@ instance HasExpressions (CS.Module a) a where
 instance HasExpressions (CS.Decl a) a where
     expressions decl = case decl of
         CS.FunctionDecl _ _ _ eqs    -> expressions eqs
-        CS.ClassDecl _ _ _ _ _ ds    -> expressions ds
+        CS.ClassDecl _ _ _ _ _ _ ds  -> expressions ds
         CS.InstanceDecl _ _ _ _ _ ds -> expressions ds
         _ -> [] -- TODO
 
@@ -172,7 +172,7 @@ instance HasDeclarations (CS.Module a) a where
 instance HasDeclarations (CS.Decl a) a where
     declarations decl = decl : case decl of
         -- TODO: Fetch declarations inside equations/expressions/...
-        CS.ClassDecl _ _ _ _ _ ds     -> ds
+        CS.ClassDecl _ _ _ _ _ _ ds   -> ds
         CS.InstanceDecl  _ _ _ _ _ ds -> ds
         _                             -> []
 
@@ -207,7 +207,7 @@ instance HasQualIdentifiers (CS.Decl a) where
         CS.FunctionDecl _ _ _ es     -> qualIdentifiers es
         CS.PatternDecl _ p rhs       -> qualIdentifiers p ++ qualIdentifiers rhs
         CS.DefaultDecl _ es          -> qualIdentifiers es
-        CS.ClassDecl _ _ _ _ _ ds    -> qualIdentifiers ds
+        CS.ClassDecl _ _ _ _ _ _ ds  -> qualIdentifiers ds
         CS.InstanceDecl _ _ _ q _ ds -> q : qualIdentifiers ds
         _                            -> []
 
@@ -360,19 +360,22 @@ instance HasIdentifiers CS.Import where
 
 instance HasIdentifiers (CS.Decl a) where
     identifiers decl = case decl of
-        CS.InfixDecl _ _ _ is         -> is
-        CS.DataDecl _ i is cdecls _   -> (i : is) ++ identifiers cdecls
-        CS.ExternalDataDecl _ i is    -> i : is
-        CS.NewtypeDecl _ i is cdecl _ -> (i : is) ++ identifiers cdecl
-        CS.TypeDecl _ i is t          -> (i : is) ++ identifiers t
-        CS.TypeSig _ is t             -> is ++ identifiers t
-        CS.FunctionDecl _ _ i es      -> i : identifiers es
-        CS.ExternalDecl _ vs          -> identifiers vs
-        CS.PatternDecl _ p rhs        -> identifiers p ++ identifiers rhs
-        CS.FreeDecl _ vs              -> identifiers vs
-        CS.DefaultDecl _ ts           -> identifiers ts
-        CS.ClassDecl _ _ c i1 i2 ds   -> identifiers c ++ i1 : i2 : identifiers ds
-        CS.InstanceDecl _ _ c _ _ ds  -> identifiers c ++ identifiers ds
+        CS.InfixDecl _ _ _ is             -> is
+        CS.DataDecl _ i is cdecls _       -> (i : is) ++ identifiers cdecls
+        CS.ExternalDataDecl _ i is        -> i : is
+        CS.NewtypeDecl _ i is cdecl _     -> (i : is) ++ identifiers cdecl
+        CS.TypeDecl _ i is t              -> (i : is) ++ identifiers t
+        CS.TypeSig _ is t                 -> is ++ identifiers t
+        CS.FunctionDecl _ _ i es          -> i : identifiers es
+        CS.ExternalDecl _ vs              -> identifiers vs
+        CS.PatternDecl _ p rhs            -> identifiers p ++ identifiers rhs
+        CS.FreeDecl _ vs                  -> identifiers vs
+        CS.DefaultDecl _ ts               -> identifiers ts
+        CS.ClassDecl _ _ c i tvs fdeps ds -> identifiers c ++ i : tvs ++ identifiers fdeps ++ identifiers ds
+        CS.InstanceDecl _ _ c _ _ ds      -> identifiers c ++ identifiers ds
+
+instance HasIdentifiers CS.FunDep where
+    identifiers (CS.FunDep _ is1 is2) = is1 ++ is2
 
 instance HasIdentifiers CS.Constraint where
     identifiers (CS.Constraint _ _ t) = identifiers t
@@ -505,10 +508,10 @@ class HasIdentifier e where
 
 instance HasIdentifier (CS.Decl a) where
     identifier decl = case decl of
-        CS.DataDecl _ ident _ _ _     -> Just ident
-        CS.ExternalDataDecl _ ident _ -> Just ident
-        CS.NewtypeDecl _ ident _ _ _  -> Just ident
-        CS.TypeDecl _ ident _ _       -> Just ident
-        CS.FunctionDecl _ _ ident _   -> Just ident
-        CS.ClassDecl _ _ _ ident _ _  -> Just ident
-        _                             -> Nothing
+        CS.DataDecl _ ident _ _ _      -> Just ident
+        CS.ExternalDataDecl _ ident _  -> Just ident
+        CS.NewtypeDecl _ ident _ _ _   -> Just ident
+        CS.TypeDecl _ ident _ _        -> Just ident
+        CS.FunctionDecl _ _ ident _    -> Just ident
+        CS.ClassDecl _ _ _ ident _ _ _ -> Just ident
+        _                              -> Nothing

--- a/src/Curry/LanguageServer/Utils/Syntax.hs
+++ b/src/Curry/LanguageServer/Utils/Syntax.hs
@@ -81,7 +81,7 @@ instance HasExpressions (CS.Decl a) a where
         _ -> [] -- TODO
 
 instance HasExpressions (CS.Equation a) a where
-    expressions (CS.Equation _ _ rhs) = expressions rhs
+    expressions (CS.Equation _ _ _ rhs) = expressions rhs
 
 instance HasExpressions (CS.Rhs a) a where
     expressions rhs = case rhs of
@@ -226,7 +226,7 @@ instance HasQualIdentifiers CS.NewConstrDecl where
         CS.NewRecordDecl _ _ (_, t) -> qualIdentifiers t
 
 instance HasQualIdentifiers (CS.Equation a) where
-    qualIdentifiers (CS.Equation _ lhs rhs) = qualIdentifiers lhs ++ qualIdentifiers rhs
+    qualIdentifiers (CS.Equation _ _ lhs rhs) = qualIdentifiers lhs ++ qualIdentifiers rhs
 
 instance HasQualIdentifiers (CS.Lhs a) where
     qualIdentifiers lhs = case lhs of
@@ -378,7 +378,7 @@ instance HasIdentifiers CS.Constraint where
     identifiers (CS.Constraint _ _ t) = identifiers t
 
 instance HasIdentifiers (CS.Equation a) where
-    identifiers (CS.Equation _ lhs rhs) = identifiers lhs ++ identifiers rhs
+    identifiers (CS.Equation _ _ lhs rhs) = identifiers lhs ++ identifiers rhs
 
 instance HasIdentifiers (CS.Pattern a) where
     identifiers pat = case pat of

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,11 +16,26 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 extra-deps:
+  - aeson-2.2.3.0
+  - binary-0.8.9.2
+  - bytestring-0.12.1.0
+  - character-ps-0.1
+  - containers-0.7
+  - directory-1.3.8.5
+  - extra-1.8
+  - filepath-1.4.300.2
   - lsp-2.7.0.0
   - lsp-types-2.3.0.0
+  - parsec-3.1.17.0
+  - process-1.6.20.0
   - set-extra-1.4.2
+  - text-2.1.1
+  - time-1.9.3
+  - unix-2.8.5.1
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: bd1750a68e011e56c176491a558885b5268173b5
+    commit: 67adff16d1166286db21e2fbddb88724674c95e9
+
+allow-newer: true
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,6 +32,7 @@ extra-deps:
   - text-2.1.1
   - time-1.9.3
   - unix-2.8.5.1
+  - Win32-2.14.1.0
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     commit: 67adff16d1166286db21e2fbddb88724674c95e9
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies.
-resolver: lts-22.30
+resolver: lts-22.41
 
 # User packages to be built.
 packages:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -38,7 +38,7 @@ packages:
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:
-    sha256: 795b7a893148a42f09956611a0fa1139293fe6ef934d053468d8e53e3e013390
-    size: 719577
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml
-  original: lts-22.30
+    sha256: 1e32b51d9082fdf6f3bd92accc9dfffd4ddaf406404427fb10bf76d2bc03cbbb
+    size: 720263
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/41.yaml
+  original: lts-22.41

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -117,6 +117,13 @@ packages:
   original:
     hackage: unix-2.8.5.1
 - completed:
+    hackage: Win32-2.14.1.0@sha256:983e8882ad5663fc3b738044dbebfe42fd4e37f7f3d7c7e0b085702c9ece6d9f,5753
+    pantry-tree:
+      sha256: 3dee6648c08272ef629d7cd045ba05ee28212469ebae72d3b2175c785c677051
+      size: 8300
+  original:
+    hackage: Win32-2.14.1.0
+- completed:
     commit: 67adff16d1166286db21e2fbddb88724674c95e9
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,62 @@
 
 packages:
 - completed:
+    hackage: aeson-2.2.3.0@sha256:011fa2d67d7a821aa5ec5c825adc919bb067d42dde8fac7c6e5db23239a58866,6589
+    pantry-tree:
+      sha256: e928995a568c7437575160844341219a5b057fc8e27f51162da8595692e2500c
+      size: 83371
+  original:
+    hackage: aeson-2.2.3.0
+- completed:
+    hackage: binary-0.8.9.2@sha256:03381e511429c44d13990c6d76281c4fc2468371cede4fe684b0c98d9b7d5f5a,6611
+    pantry-tree:
+      sha256: 7fac13c81b45416bd082c34e31cc3ac19226dd15354f379156922ad4cfbe6285
+      size: 1976
+  original:
+    hackage: binary-0.8.9.2
+- completed:
+    hackage: bytestring-0.12.1.0@sha256:98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9,9473
+    pantry-tree:
+      sha256: 89aac3892a1f67b0b18fec87ac3eaf417b8698e5f231a25b571ac91d085943d3
+      size: 4650
+  original:
+    hackage: bytestring-0.12.1.0
+- completed:
+    hackage: character-ps-0.1@sha256:b38ed1c07ae49e7461e44ca1d00c9ca24d1dcb008424ccd919916f92fd48d9fe,1315
+    pantry-tree:
+      sha256: 22d98d7c8b4c2bb9cb7fe429adf52bfed0c18269eac146b1e591c5941e26161a
+      size: 382
+  original:
+    hackage: character-ps-0.1
+- completed:
+    hackage: containers-0.7@sha256:e9b5fdcc609159410d408c47e0be13663bb0b4a42a5183b52aa0ac9c99e1dfec,2668
+    pantry-tree:
+      sha256: 265b0a6110df990b5f9f04d21856333ed5ed66f37a4b0a0215901d831f69629b
+      size: 2954
+  original:
+    hackage: containers-0.7
+- completed:
+    hackage: directory-1.3.8.5@sha256:fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b,3166
+    pantry-tree:
+      sha256: d11130a0ca9e7c8720ed1ceef4e2f0d9be4b446e67e7d15d634763a5c952877e
+      size: 3519
+  original:
+    hackage: directory-1.3.8.5
+- completed:
+    hackage: extra-1.8@sha256:57d9200fbea2e88e05e0be35925511764827b1c86d3214106b0b610f331fc40c,2725
+    pantry-tree:
+      sha256: 3aafb822ea6975fa23384ef35d82bd67442b302795bf6a58c98b366e75302a1f
+      size: 1961
+  original:
+    hackage: extra-1.8
+- completed:
+    hackage: filepath-1.4.300.2@sha256:345cbb1afe414a09e47737e4d14cbd51891a734e67c0ef3d77a1439518bb81e8,5900
+    pantry-tree:
+      sha256: 2420f7addc917bf41970a8980f52abe431b1a0fb711b00795effbb289c8ea76c
+      size: 3998
+  original:
+    hackage: filepath-1.4.300.2
+- completed:
     hackage: lsp-2.7.0.0@sha256:2a64b40a69fd9638056ca552d5660203019473061cff1d09dccc0c94e40a275c,3834
     pantry-tree:
       sha256: 630a5e18d7783c35a296268959c8d9348ee6dc94540047ea58146b310d8de941
@@ -19,6 +75,20 @@ packages:
   original:
     hackage: lsp-types-2.3.0.0
 - completed:
+    hackage: parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56,5149
+    pantry-tree:
+      sha256: 0922d72bd7115bbb590757bd92a827021dfe745ed6c0cd22856f767bee83d91f
+      size: 2810
+  original:
+    hackage: parsec-3.1.17.0
+- completed:
+    hackage: process-1.6.20.0@sha256:2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03,2790
+    pantry-tree:
+      sha256: 14d1e9a5ec731766e43c7eb9c2dc59a7da48d98d43374d9d83e725d8891c6173
+      size: 1789
+  original:
+    hackage: process-1.6.20.0
+- completed:
     hackage: set-extra-1.4.2@sha256:a1a3899d7ae01cd72dfd4691ae77cf26e8867731dff70e61307f25ddc7fd875d,564
     pantry-tree:
       sha256: 439f8bd6732a4d250a9e565c5bbcf393f3374e8e346e634494efd62b388fe810
@@ -26,15 +96,36 @@ packages:
   original:
     hackage: set-extra-1.4.2
 - completed:
-    commit: bd1750a68e011e56c176491a558885b5268173b5
+    hackage: text-2.1.1@sha256:78c3fb91055d0607a80453327f087b9dc82168d41d0dca3ff410d21033b5e87d,10653
+    pantry-tree:
+      sha256: 8251d517ceafa2680250ddb939f4a2b89bf231314cf6a218134af900e154d7cd
+      size: 8413
+  original:
+    hackage: text-2.1.1
+- completed:
+    hackage: time-1.9.3@sha256:8f1b5448722a12a952248b356c9eb366e351226543d9086a2da71270522d5f45,5679
+    pantry-tree:
+      sha256: a1043c1719491764f0fa37a1fd70d9451080548a41632fee88d8e1b8db4942d6
+      size: 6558
+  original:
+    hackage: time-1.9.3
+- completed:
+    hackage: unix-2.8.5.1@sha256:3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06,9808
+    pantry-tree:
+      sha256: b961320db69795a16c4ef4eebb0a3e7ddbbbe506fa1e22dde95ee8d8501bfbe5
+      size: 5821
+  original:
+    hackage: unix-2.8.5.1
+- completed:
+    commit: 67adff16d1166286db21e2fbddb88724674c95e9
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 911cb32d609278b24516b1412aede02daa88f933dc2935399821d418b881ab46
-      size: 17097
-    version: 2.1.1
+      sha256: 133ea80a7949bf765a43c7cd571ecd7f94103b9c54f1134d650d1dc2dd70be74
+      size: 20424
+    version: 3.0.0
   original:
-    commit: bd1750a68e011e56c176491a558885b5268173b5
+    commit: 67adff16d1166286db21e2fbddb88724674c95e9
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:


### PR DESCRIPTION
Support for Multi-Parameter Type Classes and functional dependencies was [recently merged upstream](https://git.ps.informatik.uni-kiel.de/curry/curry-frontend/-/commit/67adff16d1166286db21e2fbddb88724674c95e9). This PR updates the Curry frontend to the corresponding version, along with the required dependency bumps, and updates the language server to handle the added support for multiple type variables and functional dependencies in the syntax tree.