### PR TITLE
Add support for hover extensions

### DIFF
--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -31,6 +31,7 @@ library
       Curry.LanguageServer.CPM.Deps
       Curry.LanguageServer.CPM.Monad
       Curry.LanguageServer.CPM.Process
+      Curry.LanguageServer.Extension
       Curry.LanguageServer.FileLoader
       Curry.LanguageServer.Handlers
       Curry.LanguageServer.Handlers.Cancel

--- a/src/Curry/LanguageServer/Config.hs
+++ b/src/Curry/LanguageServer/Config.hs
@@ -5,6 +5,7 @@ module Curry.LanguageServer.Config
     ) where
 
 import Colog.Core (Severity (..))
+import Curry.LanguageServer.Extension (Extension (..))
 import Data.Aeson
     ( FromJSON (..)
     , ToJSON (..)
@@ -26,6 +27,7 @@ data Config = Config { forceRecompilation :: Bool
                      , logLevel :: LogLevel
                      , curryPath :: String
                      , useSnippetCompletions :: Bool
+                     , extensions :: [Extension]
                      }
     deriving (Show, Eq)
 
@@ -36,6 +38,7 @@ instance Default Config where
                  , logLevel = LogLevel Info
                  , curryPath = "pakcs"
                  , useSnippetCompletions = False
+                 , extensions = []
                  }
 
 instance FromJSON Config where
@@ -46,6 +49,7 @@ instance FromJSON Config where
         logLevel              <- l .:? "logLevel"              .!= (def @Config).logLevel
         curryPath             <- l .:? "curryPath"             .!= (def @Config).curryPath
         useSnippetCompletions <- l .:? "useSnippetCompletions" .!= (def @Config).useSnippetCompletions
+        extensions            <- l .:? "extensions"            .!= (def @Config).extensions
         return Config {..}
 
 instance ToJSON Config where
@@ -56,6 +60,7 @@ instance ToJSON Config where
         , "logLevel"              .= logLevel
         , "curryPath"             .= curryPath
         , "useSnippetCompletions" .= useSnippetCompletions
+        , "extensions"            .= extensions
         ]
         
 instance FromJSON LogLevel where

--- a/src/Curry/LanguageServer/Extension.hs
+++ b/src/Curry/LanguageServer/Extension.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveGeneric, OverloadedStrings, TypeApplications #-}
+module Curry.LanguageServer.Extension
+    ( ExtensionPoint (..), Extension (..)
+    ) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import qualified Data.Text as T
+import GHC.Generics (Generic (..))
+
+data ExtensionPoint = ExtensionPointHover
+    deriving (Show, Eq)
+
+data Extension = Extension
+    { name :: T.Text
+    , extensionPoint :: ExtensionPoint
+    , executable :: T.Text
+    , args :: [T.Text]
+    }
+    deriving (Show, Eq, Generic)
+
+instance FromJSON Extension where
+
+instance ToJSON Extension where
+
+instance FromJSON ExtensionPoint where
+    parseJSON v = do
+        s <- parseJSON v
+        return $ case s :: T.Text of
+            "hover" -> ExtensionPointHover
+            _       -> error $ "Could not parse extension point " ++ T.unpack s
+
+instance ToJSON ExtensionPoint where
+    toJSON p = toJSON @T.Text $ case p of
+        ExtensionPointHover -> "hover"

--- a/src/Curry/LanguageServer/Extension.hs
+++ b/src/Curry/LanguageServer/Extension.hs
@@ -17,39 +17,43 @@ data ExtensionOutputFormat = ExtensionOutputFormatPlaintext
     deriving (Show, Eq)
 
 data Extension = Extension
-    { name           :: T.Text
-    , extensionPoint :: ExtensionPoint
-    , outputFormat   :: ExtensionOutputFormat
-    , executable     :: T.Text
-    , args           :: [T.Text]
+    { name              :: T.Text
+    , extensionPoint    :: ExtensionPoint
+    , outputFormat      :: ExtensionOutputFormat
+    , showOutputOnError :: Bool
+    , executable        :: T.Text
+    , args              :: [T.Text]
     }
     deriving (Show, Eq)
 
 instance Default Extension where
     def = Extension
-        { name           = "Anonymous Extension"
-        , extensionPoint = ExtensionPointHover
-        , outputFormat   = ExtensionOutputFormatPlaintext
-        , executable     = "echo"
-        , args           = []
+        { name              = "Anonymous Extension"
+        , extensionPoint    = ExtensionPointHover
+        , outputFormat      = ExtensionOutputFormatPlaintext
+        , showOutputOnError = False
+        , executable        = "echo"
+        , args              = []
         }
 
 instance FromJSON Extension where
     parseJSON = withObject "Extension" $ \e -> do
-        name           <- e .:? "name"           .!= (def @Extension).name
-        extensionPoint <- e .:? "extensionPoint" .!= (def @Extension).extensionPoint
-        outputFormat   <- e .:? "outputFormat"   .!= (def @Extension).outputFormat
-        executable     <- e .:? "executable"     .!= (def @Extension).executable
-        args           <- e .:? "args"           .!= (def @Extension).args
+        name              <- e .:? "name"              .!= (def @Extension).name
+        extensionPoint    <- e .:? "extensionPoint"    .!= (def @Extension).extensionPoint
+        outputFormat      <- e .:? "outputFormat"      .!= (def @Extension).outputFormat
+        showOutputOnError <- e .:? "showOutputOnError" .!= (def @Extension).showOutputOnError
+        executable        <- e .:? "executable"        .!= (def @Extension).executable
+        args              <- e .:? "args"              .!= (def @Extension).args
         return Extension {..}
 
 instance ToJSON Extension where
     toJSON Extension {..} = object
-        [ "name"           .= name
-        , "extensionPoint" .= extensionPoint
-        , "outputFormat"   .= outputFormat
-        , "executable"     .= executable
-        , "args"           .= args
+        [ "name"              .= name
+        , "extensionPoint"    .= extensionPoint
+        , "outputFormat"      .= outputFormat
+        , "showOutputOnError" .= showOutputOnError
+        , "executable"        .= executable
+        , "args"              .= args
         ]
 
 instance FromJSON ExtensionPoint where

--- a/src/Curry/LanguageServer/Extension.hs
+++ b/src/Curry/LanguageServer/Extension.hs
@@ -8,6 +8,7 @@ import qualified Data.Text as T
 import GHC.Generics (Generic (..))
 
 data ExtensionPoint = ExtensionPointHover
+                    | ExtensionPointUnknown T.Text
     deriving (Show, Eq)
 
 data Extension = Extension
@@ -27,8 +28,9 @@ instance FromJSON ExtensionPoint where
         s <- parseJSON v
         return $ case s :: T.Text of
             "hover" -> ExtensionPointHover
-            _       -> error $ "Could not parse extension point " ++ T.unpack s
+            _       -> ExtensionPointUnknown s
 
 instance ToJSON ExtensionPoint where
     toJSON p = toJSON @T.Text $ case p of
-        ExtensionPointHover -> "hover"
+        ExtensionPointHover     -> "hover"
+        ExtensionPointUnknown s -> s

--- a/src/Curry/LanguageServer/Extension.hs
+++ b/src/Curry/LanguageServer/Extension.hs
@@ -17,11 +17,11 @@ data ExtensionOutputFormat = ExtensionOutputFormatPlaintext
     deriving (Show, Eq)
 
 data Extension = Extension
-    { name :: T.Text
+    { name           :: T.Text
     , extensionPoint :: ExtensionPoint
-    , outputFormat :: ExtensionOutputFormat
-    , executable :: T.Text
-    , args :: [T.Text]
+    , outputFormat   :: ExtensionOutputFormat
+    , executable     :: T.Text
+    , args           :: [T.Text]
     }
     deriving (Show, Eq)
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -13,7 +13,7 @@ import Control.Monad.Trans.Maybe (MaybeT (..))
 import qualified Curry.LanguageServer.Config as CFG
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
-import Curry.LanguageServer.Extension (ExtensionPoint (..), Extension (..))
+import Curry.LanguageServer.Extension (ExtensionPoint (..), ExtensionOutputFormat (..), Extension (..))
 import Curry.LanguageServer.Utils.Convert (ppPredTypeToText, currySpanInfo2Range)
 import Curry.LanguageServer.Index.Resolve (resolveAtPos)
 import Curry.LanguageServer.Utils.General (liftMaybe)
@@ -91,7 +91,10 @@ extensionHover ast pos e = case e.extensionPoint of
                 | T.null t  = ""
                 | otherwise =  "```\n" <> t <> "\n```"
             text            = case exitCode of
-                                 ExitSuccess -> T.pack out
+                                 ExitSuccess ->
+                                    case e.outputFormat of
+                                        ExtensionOutputFormatMarkdown  -> T.pack out
+                                        _                              -> simpleCodeBlock (T.pack out)
                                  _           -> T.unlines
                                     [ "_Extension `" <> e.name <> "` exited with " <> T.pack (show exitCode) <> "_"
                                     , simpleCodeBlock (T.pack err)

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -90,13 +90,15 @@ extensionHover ast pos e = case e.extensionPoint of
         let simpleCodeBlock t
                 | T.null t  = ""
                 | otherwise =  "```\n" <> t <> "\n```"
-            text            = case exitCode of
+            text            = T.unlines $ case exitCode of
                                  ExitSuccess ->
-                                    case e.outputFormat of
+                                    [ "**" <> e.name <> "**"
+                                    , case e.outputFormat of
                                         ExtensionOutputFormatMarkdown  -> T.pack out
                                         _                              -> simpleCodeBlock (T.pack out)
-                                 _           -> T.unlines
-                                    [ "_Extension `" <> e.name <> "` exited with " <> T.pack (show exitCode) <> "_"
+                                    ]
+                                 _           ->
+                                    [ "_Extension **" <> e.name <> "** exited with " <> T.pack (show exitCode) <> "_"
                                     , simpleCodeBlock (T.pack err)
                                     ]
             contents        = J.InL $ J.MarkupContent J.MarkupKind_Markdown text

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -87,13 +87,13 @@ extensionHover ast pos e = case e.extensionPoint of
 
         (exitCode, out, err) <- MaybeT $ liftIO $ timeout timeoutMicros $ readCreateProcessWithExitCode procOpts ""
 
-        let simpleCodeBlock s'
-                | null s'   = ""
-                | otherwise =  "```\n" <> T.pack s' <> "\n```"
+        let simpleCodeBlock t
+                | T.null t  = ""
+                | otherwise =  "```\n" <> t <> "\n```"
             text            = case exitCode of
-                                 ExitSuccess -> simpleCodeBlock out
+                                 ExitSuccess -> T.pack out
                                  _           -> "_Extension " <> e.name <> " timed out after " <> T.pack (show timeoutSecs) <> " seconds_"
-                                                              <> simpleCodeBlock err
+                                                              <> simpleCodeBlock (T.pack err)
             contents        = J.InL $ J.MarkupContent J.MarkupKind_Markdown text
             range           = currySpanInfo2Range spi
         
@@ -122,7 +122,7 @@ joinMarkupContent cs = foldr1 mergeMarkupContent cs
 
 mergeMarkupContent :: J.MarkupContent -> J.MarkupContent -> J.MarkupContent
 mergeMarkupContent (normalizeToMarkdown -> J.MarkupContent _ t1) (normalizeToMarkdown -> J.MarkupContent _ t2) =
-    J.MarkupContent J.MarkupKind_Markdown $ T.unlines [t1, t2]
+    J.MarkupContent J.MarkupKind_Markdown $ T.unlines [t1, "", "---", "", t2]
 
 emptyMarkupContent :: J.MarkupContent
 emptyMarkupContent = J.MarkupContent J.MarkupKind_PlainText ""

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -82,7 +82,7 @@ extensionHover ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = case e
         let timeoutSecs    = 10
             timeoutMicros  = timeoutSecs * 1_000_000
             templateParams = [ ("currentFile", T.pack (fromMaybe "" (uriToFilePath uri)))
-                             , ("currentUri", T.pack (show uri))
+                             , ("currentUri", J.getUri uri)
                              , ("currentModule", ppToText mid)
                              , ("line", T.pack (show l))
                              , ("column", T.pack (show c))

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -92,8 +92,10 @@ extensionHover ast pos e = case e.extensionPoint of
                 | otherwise =  "```\n" <> t <> "\n```"
             text            = case exitCode of
                                  ExitSuccess -> T.pack out
-                                 _           -> "_Extension " <> e.name <> " timed out after " <> T.pack (show timeoutSecs) <> " seconds_"
-                                                              <> simpleCodeBlock (T.pack err)
+                                 _           -> T.unlines
+                                    [ "_Extension `" <> e.name <> "` exited with " <> T.pack (show exitCode) <> "_"
+                                    , simpleCodeBlock (T.pack err)
+                                    ]
             contents        = J.InL $ J.MarkupContent J.MarkupKind_Markdown text
             range           = currySpanInfo2Range spi
         

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -86,7 +86,8 @@ extensionHover ast pos@(J.Position l c) uri e = case e.extensionPoint of
                              , ("line", T.pack (show l))
                              , ("column", T.pack (show c))
                              ] :: [(T.Text, T.Text)]
-            evalTemplate t = foldr (\(p, r) -> T.replace ("{" <> p <> "}") r) t templateParams
+            applyParam p v = T.replace p ("{" <> v <> "}")
+            evalTemplate t = foldr (uncurry applyParam) t templateParams
             procOpts       = proc (T.unpack e.executable) (T.unpack . (evalTemplate :: T.Text -> T.Text) <$> e.args)
 
         (exitCode, out, err) <- MaybeT $ liftIO $ timeout timeoutMicros $ readCreateProcessWithExitCode procOpts ""

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -89,7 +89,7 @@ extensionHover ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = case e
                              , ("expression", expr)
                              , ("type", maybe "?" (ppPredTypeToText mid) ty)
                              ] :: [(T.Text, T.Text)]
-            applyParam p v = T.replace p ("{" <> v <> "}")
+            applyParam p   = T.replace ("{" <> p <> "}")
             evalTemplate t = foldr (uncurry applyParam) t templateParams
             procOpts       = proc (T.unpack e.executable) (T.unpack . (evalTemplate :: T.Text -> T.Text) <$> e.args)
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -73,6 +73,7 @@ typedSpanInfoHover ast@(moduleIdentifier -> mid) pos = do
 extensionHover :: Extension -> ModuleAST -> J.Position -> Maybe J.Hover
 extensionHover e _ _ = case e.extensionPoint of
     ExtensionPointHover -> Nothing -- TODO
+    _                   -> Nothing
 
 previewHover :: J.Hover -> T.Text
 previewHover = T.unlines . (previewMarkupContent <$>) . normalizeHoverContents . (^. J.contents)

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -31,7 +31,7 @@ import qualified Language.LSP.Protocol.Lens as J
 import qualified Language.LSP.Protocol.Message as J
 import Language.LSP.Server (MonadLsp)
 import System.Exit (ExitCode (..))
-import System.Process (readCreateProcessWithExitCode, shell, CreateProcess (..))
+import System.Process (readCreateProcessWithExitCode, proc)
 import System.Timeout (timeout)
 
 hoverHandler :: S.Handlers LSM
@@ -83,7 +83,7 @@ extensionHover ast pos e = case e.extensionPoint of
             timeoutMicros = timeoutSecs * 1_000_000
             -- TODO: Template parameters
             -- TODO: cwd
-            procOpts      = shell (unwords (T.unpack <$> (e.executable : e.args)))
+            procOpts      = proc (T.unpack e.executable) (T.unpack <$> e.args)
 
         (exitCode, out, err) <- MaybeT $ liftIO $ timeout timeoutMicros $ readCreateProcessWithExitCode procOpts ""
 

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -93,12 +93,14 @@ extensionHover ast pos e = case e.extensionPoint of
             text            = T.unlines $ case exitCode of
                                  ExitSuccess ->
                                     [ "**" <> e.name <> "**"
+                                    , ""
                                     , case e.outputFormat of
                                         ExtensionOutputFormatMarkdown  -> T.pack out
                                         _                              -> simpleCodeBlock (T.pack out)
                                     ]
                                  _           ->
                                     [ "_Extension **" <> e.name <> "** exited with " <> T.pack (show exitCode) <> "_"
+                                    , ""
                                     , simpleCodeBlock (T.pack err)
                                     ]
             contents        = J.InL $ J.MarkupContent J.MarkupKind_Markdown text

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -81,11 +81,11 @@ extensionHover ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = case e
 
         let timeoutSecs    = 10
             timeoutMicros  = timeoutSecs * 1_000_000
-            templateParams = [ ("sourceFile", T.pack (fromMaybe "" (uriToFilePath uri)))
-                             , ("sourceUri", T.pack (show uri))
+            templateParams = [ ("currentFile", T.pack (fromMaybe "" (uriToFilePath uri)))
+                             , ("currentUri", T.pack (show uri))
+                             , ("currentModule", ppToText mid)
                              , ("line", T.pack (show l))
                              , ("column", T.pack (show c))
-                             , ("module", ppToText mid)
                              , ("expression", expr)
                              , ("type", maybe "?" (ppPredTypeToText mid) ty)
                              ] :: [(T.Text, T.Text)]

--- a/src/Curry/LanguageServer/Utils/Sema.hs
+++ b/src/Curry/LanguageServer/Utils/Sema.hs
@@ -27,7 +27,11 @@ untypedTopLevelDecls (CS.Module _ _ _ _ _ _ decls) = untypedDecls
     where typeSigIdents = S.fromList [i | CS.TypeSig _ is _ <- decls, i <- is]
           untypedDecls = [(spi, i, t) | CS.FunctionDecl spi t i _ <- decls, i `S.notMember` typeSigIdents]
 
-data TypedSpanInfo a = TypedSpanInfo T.Text a CSPI.SpanInfo
+data TypedSpanInfo a = TypedSpanInfo
+    { exprText       :: T.Text
+    , typeAnnotation :: a
+    , spanInfo       :: CSPI.SpanInfo
+    }
     deriving (Show, Eq)
 
 class HasTypedSpanInfos e a where


### PR DESCRIPTION
### Fixes #69

This implements support for adding user-defined hovers via external commands, so-called extensions, which can be configured via the config (in VSCode `settings.json`):

```json
{
  "curry.languageServer.extensions": [
    {
      "name": "Example Extension",
      "extensionPoint": "hover",
      "executable": "printf",
      "args": [
        "%s\n",
        "This is an example output:",
        "Current File:   {currentFile}",
        "Current URI:    {currentUri}",
        "Current Module: {currentModule}",
        "Line:           {line}",
        "Column:         {column}",
        "Type:           {type}",
        "Identifier:     {identifier}",
        "Module:         {module}"
      ]
    }
  ]
}
```

Other extension points may be added in the future.

### To do

- [x] Implement hover extensions
- [x] Add some basic template parameters
  - [x] `currentFile`, `currentUri` and `currentModule`
  - [x] `line` and `column`
  - [x] `identifier` and `type` (when local type information is available)
  - [x] `module` (the imported module where the identifier is from, if available)