### PR TITLE
Expose SymbolKind in hover extensions

### DIFF
--- a/src/Curry/LanguageServer/Handlers/Config.hs
+++ b/src/Curry/LanguageServer/Handlers/Config.hs
@@ -8,5 +8,5 @@ import Curry.LanguageServer.Monad (LSM)
 import Curry.LanguageServer.Utils.Logging (infoM)
 
 onConfigChange :: Config -> LSM ()
-onConfigChange cfg = do
+onConfigChange _cfg = do
     infoM "Changed configuration"

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -235,7 +235,7 @@ instance ToCompletionItems CompletionSymbol where
                   I.TypeAlias                                 -> J.CompletionItemKind_Interface
                   I.TypeClass                                 -> J.CompletionItemKind_Interface
                   I.TypeVar                                   -> J.CompletionItemKind_Variable
-                  I.Other                                     -> J.CompletionItemKind_Text
+                  I.Unknown                                   -> J.CompletionItemKind_Text
               insertText | opts.useSnippets = Just $ makeSnippet name s.printedArgumentTypes
                          | otherwise        = Just name
               insertTextFormat | opts.useSnippets = Just J.InsertTextFormat_Snippet

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -87,6 +87,7 @@ extensionHover store ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = 
                              , ("type", fromMaybe "" ((.printedType) =<< symbol))
                              , ("identifier", maybe "" (.ident) symbol)
                              , ("module", maybe "" symbolParentIdent symbol)
+                             , ("symbolKind", maybe "" (T.pack . show . (.kind)) symbol)
                              ] :: [(T.Text, T.Text)]
             applyParam p   = T.replace ("{" <> p <> "}")
             evalTemplate t = foldr (uncurry applyParam) t templateParams

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -87,7 +87,7 @@ extensionHover store ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = 
                              , ("type", fromMaybe "" ((.printedType) =<< symbol))
                              , ("identifier", maybe "" (.ident) symbol)
                              , ("module", maybe "" symbolParentIdent symbol)
-                             , ("symbolKind", T.pack (show (maybe I.Other (.kind) symbol)))
+                             , ("symbolKind", T.pack (show (maybe I.Unknown (.kind) symbol)))
                              ] :: [(T.Text, T.Text)]
             applyParam p   = T.replace ("{" <> p <> "}")
             evalTemplate t = foldr (uncurry applyParam) t templateParams

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -87,7 +87,7 @@ extensionHover store ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = 
                              , ("type", fromMaybe "" ((.printedType) =<< symbol))
                              , ("identifier", maybe "" (.ident) symbol)
                              , ("module", maybe "" symbolParentIdent symbol)
-                             , ("symbolKind", maybe "" (T.pack . show . (.kind)) symbol)
+                             , ("symbolKind", T.pack (show (maybe I.Other (.kind) symbol)))
                              ] :: [(T.Text, T.Text)]
             applyParam p   = T.replace ("{" <> p <> "}")
             evalTemplate t = foldr (uncurry applyParam) t templateParams

--- a/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
+++ b/src/Curry/LanguageServer/Handlers/Workspace/Symbol.hs
@@ -47,7 +47,7 @@ toWorkspaceSymbol s = J.SymbolInformation name kind tags containerName deprecate
               I.TypeAlias                                 -> J.SymbolKind_Interface
               I.TypeClass                                 -> J.SymbolKind_Interface
               I.TypeVar                                   -> J.SymbolKind_Variable
-              I.Other                                     -> J.SymbolKind_Namespace
+              I.Unknown                                   -> J.SymbolKind_Namespace
           tags = Nothing
           deprecated = Nothing
           containerName = Just $ I.symbolParentIdent s

--- a/src/Curry/LanguageServer/Index/Symbol.hs
+++ b/src/Curry/LanguageServer/Index/Symbol.hs
@@ -22,7 +22,7 @@ data SymbolKind = ValueFunction
                 | TypeClass
                 | TypeAlias
                 | TypeVar
-                | Other
+                | Unknown
     deriving (Show, Eq)
 
 -- | A module, type or value. If it's a type, the 'printed type' will be the printed kind.
@@ -41,7 +41,7 @@ data Symbol = Symbol
 
 instance Default Symbol where
     def = Symbol
-        { kind = Other
+        { kind = Unknown
         , qualIdent = ""
         , ident = ""
         , printedType = Nothing


### PR DESCRIPTION
This should make it easier for clients to disambiguate identifiers. The `{symbolKind}` parameter uses the `Show` representation of this data type:

```haskell
data SymbolKind = ValueFunction
                | ValueConstructor
                | Module
                | TypeData
                | TypeNew
                | TypeClass
                | TypeAlias
                | TypeVar
                | Unknown
    deriving (Show, Eq)
```