### PR TITLE
Migrate Curry frontend imports to the new module structure

### DIFF
--- a/src/Curry/LanguageServer/Compiler.hs
+++ b/src/Curry/LanguageServer/Compiler.hs
@@ -19,19 +19,19 @@ import qualified Curry.Base.Message as CM
 import Curry.Base.Monad (CYIO, CYT, runCYIO, liftCYM, silent, failMessages, warnMessages)
 import qualified Curry.Syntax as CS
 import qualified Curry.Syntax.Extension as CSE
-import qualified Base.Messages as CBM
-import qualified Checks as CC
-import qualified CurryBuilder as CB
-import qualified CurryDeps as CD
-import qualified CompilerEnv as CE
-import qualified CondCompile as CNC
-import qualified CompilerOpts as CO
-import qualified Env.Interface as CEI
-import qualified Exports as CEX
-import qualified Imports as CIM
-import qualified Interfaces as CIF
-import qualified Modules as CMD
-import qualified Transformations as CT
+import qualified Curry.Frontend.Base.Messages as CBM
+import qualified Curry.Frontend.Checks as CC
+import qualified Curry.Frontend.CurryBuilder as CB
+import qualified Curry.Frontend.CurryDeps as CD
+import qualified Curry.Frontend.CompilerEnv as CE
+import qualified Curry.Frontend.CondCompile as CNC
+import qualified Curry.Frontend.CompilerOpts as CO
+import qualified Curry.Frontend.Env.Interface as CEI
+import qualified Curry.Frontend.Exports as CEX
+import qualified Curry.Frontend.Imports as CIM
+import qualified Curry.Frontend.Interfaces as CIF
+import qualified Curry.Frontend.Modules as CMD
+import qualified Curry.Frontend.Transformations as CT
 import qualified Text.PrettyPrint as PP
 
 import Control.Monad (join)

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeAction.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.Handlers.TextDocument.CodeAction (codeActionHandler)
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
+import qualified Curry.Frontend.Base.Types as CT
 
 import Control.Lens ((^.))
 import Control.Monad (guard)

--- a/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/CodeLens.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.Handlers.TextDocument.CodeLens (codeLensHandler) whe
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
+import qualified Curry.Frontend.Base.Types as CT
 
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (MonadIO (..))

--- a/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Completion.hs
@@ -3,7 +3,7 @@ module Curry.LanguageServer.Handlers.TextDocument.Completion (completionHandler)
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
+import qualified Curry.Frontend.Base.Types as CT
 
 import Control.Lens ((^.), (?~))
 import Control.Monad (join, guard)

--- a/src/Curry/LanguageServer/Index/Convert.hs
+++ b/src/Curry/LanguageServer/Index/Convert.hs
@@ -5,11 +5,11 @@ module Curry.LanguageServer.Index.Convert
 
 -- Curry Compiler Libraries + Dependencies
 import qualified Curry.Base.Ident as CI
-import qualified Base.TopEnv as CTE
-import qualified Base.Types as CT
-import qualified Base.Kinds as CK
-import qualified Env.TypeConstructor as CETC
-import qualified Env.Value as CEV
+import qualified Curry.Frontend.Base.TopEnv as CTE
+import qualified Curry.Frontend.Base.Types as CT
+import qualified Curry.Frontend.Base.Kinds as CK
+import qualified Curry.Frontend.Env.TypeConstructor as CETC
+import qualified Curry.Frontend.Env.Value as CEV
 
 import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (MonadIO (..))

--- a/src/Curry/LanguageServer/Index/Store.hs
+++ b/src/Curry/LanguageServer/Index/Store.hs
@@ -25,8 +25,8 @@ module Curry.LanguageServer.Index.Store
 import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.Message as CM
 import qualified Curry.Files.Filenames as CFN
-import qualified Base.TopEnv as CT
-import qualified CompilerEnv as CE
+import qualified Curry.Frontend.Base.TopEnv as CT
+import qualified Curry.Frontend.CompilerEnv as CE
 
 import Control.Exception (SomeException)
 import Control.Monad (forM_, join, void, unless, filterM)

--- a/src/Curry/LanguageServer/Utils/Convert.hs
+++ b/src/Curry/LanguageServer/Utils/Convert.hs
@@ -37,7 +37,7 @@ import qualified Curry.Base.Pretty as CPP
 import qualified Curry.Base.Span as CSP
 import qualified Curry.Base.SpanInfo as CSPI
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
+import qualified Curry.Frontend.Base.Types as CT
 import qualified Text.PrettyPrint as PP
 
 import Control.Monad.IO.Class (MonadIO (..))

--- a/src/Curry/LanguageServer/Utils/Sema.hs
+++ b/src/Curry/LanguageServer/Utils/Sema.hs
@@ -12,7 +12,7 @@ import qualified Curry.Base.Ident as CI
 import qualified Curry.Base.SpanInfo as CSPI
 import qualified Curry.Base.Position as CP
 import qualified Curry.Syntax as CS
-import qualified Base.Types as CT
+import qualified Curry.Frontend.Base.Types as CT
 
 import Curry.LanguageServer.Utils.Convert (ppToText)
 import Data.Maybe (maybeToList)

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,7 +34,7 @@ extra-deps:
   - unix-2.8.5.1
   - Win32-2.14.1.0
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: 67adff16d1166286db21e2fbddb88724674c95e9
+    commit: 81d57ee6515efb2b21fc3820ddb13c7a8badcad3
 
 allow-newer: true
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -124,15 +124,15 @@ packages:
   original:
     hackage: Win32-2.14.1.0
 - completed:
-    commit: 67adff16d1166286db21e2fbddb88724674c95e9
+    commit: 81d57ee6515efb2b21fc3820ddb13c7a8badcad3
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 133ea80a7949bf765a43c7cd571ecd7f94103b9c54f1134d650d1dc2dd70be74
-      size: 20424
+      sha256: 5a71cac15a58cf2f38efab6c8f772a58cc40266373e350328b644f106a8d469c
+      size: 21476
     version: 3.0.0
   original:
-    commit: 67adff16d1166286db21e2fbddb88724674c95e9
+    commit: 81d57ee6515efb2b21fc3820ddb13c7a8badcad3
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:


### PR DESCRIPTION
Upstream has recently moved the frontend modules under a `Curry.Frontend` prefix and this PR updates the imports accordingly here (along with bumping the frontend to the most recent `master`).