### PR TITLE
Update frontend to support case mode quick fix

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -34,7 +34,7 @@ extra-deps:
   - unix-2.8.5.1
   - Win32-2.14.1.0
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: 3904e70913651b522eef3e7febe90c54564d9c18
+    commit: 1b072df42ee1a4fc5102e1ac0281ed28072a0fe4
 
 allow-newer: true
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -124,15 +124,15 @@ packages:
   original:
     hackage: Win32-2.14.1.0
 - completed:
-    commit: 3904e70913651b522eef3e7febe90c54564d9c18
+    commit: 1b072df42ee1a4fc5102e1ac0281ed28072a0fe4
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 78878966a6bb00c266eb65f2f8a6fc630908bf5dba1de7176c9353cf4e2a87e6
+      sha256: d76276289cf44eb6feda91e24efbbd540a1ecae3499635e0ab232b01fe6f1463
       size: 21750
     version: 3.0.0
   original:
-    commit: 3904e70913651b522eef3e7febe90c54564d9c18
+    commit: 1b072df42ee1a4fc5102e1ac0281ed28072a0fe4
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:


### PR DESCRIPTION
This updates the Curry frontend to support a new quick fix for case mode warnings. Marked draft until merged upstream.