### PR TITLE
Update frontend to support quick fix for stubbing out functions without body

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -34,7 +34,7 @@ extra-deps:
   - unix-2.8.5.1
   - Win32-2.14.1.0
   - git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
-    commit: ce64f24565e7a16235918bbded4d2ee9ef770e5c
+    commit: e85243172a22cef4aa629b9411d76da29c3b8be9
 
 allow-newer: true
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -124,15 +124,15 @@ packages:
   original:
     hackage: Win32-2.14.1.0
 - completed:
-    commit: ce64f24565e7a16235918bbded4d2ee9ef770e5c
+    commit: e85243172a22cef4aa629b9411d76da29c3b8be9
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
     name: curry-frontend
     pantry-tree:
-      sha256: 6c32214f8fce18a3256db3017bbfcdff9dce820d5c6205a455c861b2bafc1bd8
+      sha256: 46a0e1cad4ebec374fe4e966766620a436f9722c06c3c3d618075457c7439a28
       size: 21750
     version: 3.0.0
   original:
-    commit: ce64f24565e7a16235918bbded4d2ee9ef770e5c
+    commit: e85243172a22cef4aa629b9411d76da29c3b8be9
     git: https://git.ps.informatik.uni-kiel.de/curry/curry-frontend.git
 snapshots:
 - completed:


### PR DESCRIPTION
This updates the Curry frontend to support a new quick fix for stubbing out functions without a body:

![image](https://github.com/user-attachments/assets/7c42fe7d-8e72-4cf0-a98e-44b4864cab67)

generating

```curry
someFunc :: Int -> Int
someFunc = failed
```

Marked draft until merged upstream.