### PR TITLE
Fix codeblocks generated for plaintext extension hovers

### DIFF
--- a/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/Hover.hs
@@ -97,7 +97,7 @@ extensionHover store ast@(moduleIdentifier -> mid) pos@(J.Position l c) uri e = 
 
         let simpleCodeBlock t
                 | T.null t  = ""
-                | otherwise =  "```\n" <> t <> "\n```"
+                | otherwise =  "```plaintext\n" <> t <> "\n```"
         
         text <- case exitCode of
             ExitSuccess             -> return $ T.unlines


### PR DESCRIPTION
### Fixes #94 

Extensions already provide the option `{ "outputFormat": "plaintext" }`, this option wasn't respected properly, however, since VSCode seems to highlight markdown codeblocks in the current source file's language by default. By explicitly marking these codeblocks as `plaintext`, they are no longer highlighted as Curry code, as expected.

Note that if Curry highlighting is desired, extension authors can still set `{ "outputFormat": "markdown" }` and generate codeblocks of the form

    ```curry
    <code goes here>
    ```