### PR TITLE
Implement references lookup (`textDocument/references`)

### DIFF
--- a/curry-language-server.cabal
+++ b/curry-language-server.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -45,6 +45,7 @@ library
       Curry.LanguageServer.Handlers.TextDocument.DocumentSymbol
       Curry.LanguageServer.Handlers.TextDocument.Hover
       Curry.LanguageServer.Handlers.TextDocument.Notifications
+      Curry.LanguageServer.Handlers.TextDocument.References
       Curry.LanguageServer.Handlers.TextDocument.SignatureHelp
       Curry.LanguageServer.Handlers.Workspace.Command
       Curry.LanguageServer.Handlers.Workspace.Symbol

--- a/src/Curry/LanguageServer/Handlers.hs
+++ b/src/Curry/LanguageServer/Handlers.hs
@@ -9,6 +9,7 @@ import Curry.LanguageServer.Handlers.TextDocument.Definition (definitionHandler)
 import Curry.LanguageServer.Handlers.TextDocument.DocumentSymbol (documentSymbolHandler)
 import Curry.LanguageServer.Handlers.TextDocument.Notifications (didOpenHandler, didChangeHandler, didSaveHandler, didCloseHandler)
 import Curry.LanguageServer.Handlers.TextDocument.Hover (hoverHandler)
+import Curry.LanguageServer.Handlers.TextDocument.References (referencesHandler)
 import Curry.LanguageServer.Handlers.TextDocument.SignatureHelp (signatureHelpHandler)
 import Curry.LanguageServer.Handlers.Workspace.Command (executeCommandHandler)
 import Curry.LanguageServer.Handlers.Workspace.Symbol (workspaceSymbolHandler)
@@ -27,6 +28,7 @@ handlers _caps = mconcat
     , workspaceSymbolHandler
     , codeActionHandler
     , codeLensHandler
+    , referencesHandler
     , signatureHelpHandler
       -- Notification handlers
     , initializedHandler

--- a/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
@@ -28,9 +28,6 @@ import qualified Language.LSP.Protocol.Lens as J
 import qualified Language.LSP.Protocol.Message as J
 import qualified Language.LSP.Protocol.Types as J
 
--- DEBUG
-import Debug.Trace
-
 referencesHandler :: S.Handlers LSM
 referencesHandler = S.requestHandler J.SMethod_TextDocumentReferences $ \req responder -> do
     debugM "Processing references request"

--- a/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
@@ -1,13 +1,68 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, NoFieldSelectors, OverloadedRecordDot #-}
 module Curry.LanguageServer.Handlers.TextDocument.References (referencesHandler) where
 
-import Curry.LanguageServer.Monad (LSM)
+-- Curry Compiler Libraries + Dependencies
+import qualified Curry.Base.SpanInfo as CSPI
+
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import qualified Curry.LanguageServer.Config as CFG
+import Curry.LanguageServer.Monad (LSM, getStore)
+import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
+import Curry.LanguageServer.Utils.General (liftMaybe, (<.$>), joinFst)
+import Curry.LanguageServer.Utils.Logging (debugM, infoM)
+import Curry.LanguageServer.Utils.Sema (ModuleAST)
+import Curry.LanguageServer.Utils.Syntax (HasQualIdentifiers (..), HasExpressions (expressions), HasQualIdentifier (qualIdentifier))
+import Curry.LanguageServer.Utils.Uri (normalizeUriWithPath)
+import Curry.LanguageServer.Index.Resolve (resolveAtPos)
+import Curry.LanguageServer.Index.Symbol (Symbol (..))
+import qualified Curry.LanguageServer.Index.Store as I
+import qualified Data.Map as M
+import Data.Maybe (fromMaybe, maybeToList)
+import qualified Data.Text as T
+import Language.LSP.Server (MonadLsp)
 import qualified Language.LSP.Server as S
+import qualified Language.LSP.Protocol.Lens as J
 import qualified Language.LSP.Protocol.Message as J
 import qualified Language.LSP.Protocol.Types as J
-import Curry.LanguageServer.Utils.Logging (debugM)
+
+-- DEBUG
+import Debug.Trace
 
 referencesHandler :: S.Handlers LSM
 referencesHandler = S.requestHandler J.SMethod_TextDocumentReferences $ \req responder -> do
     debugM "Processing references request"
-    responder $ Right $ J.InL []
+    let pos = req ^. J.params . J.position
+        uri = req ^. J.params . J.textDocument . J.uri
+    normUri <- normalizeUriWithPath uri
+    store <- getStore
+    refs <- (fromMaybe [] <$>) . runMaybeT $ do
+        lift $ debugM $ "Looking up " <> J.getUri (J.fromNormalizedUri normUri) <> " in " <> T.pack (show (M.keys store.modules))
+        entry <- I.getModule normUri
+        lift $ fetchReferences store entry pos
+    responder $ Right $ J.InL refs
+
+fetchReferences :: (MonadIO m, MonadLsp CFG.Config m) => I.IndexStore -> I.ModuleStoreEntry -> J.Position -> m [J.Location]
+fetchReferences store entry pos = do
+    defs <- (fromMaybe [] <$>) . runMaybeT $ do
+        ast <- liftMaybe entry.moduleAST
+        references store ast pos
+    infoM $ "Found " <> T.pack (show (length defs)) <> " reference(s)"
+    return defs
+
+references :: MonadIO m => I.IndexStore -> ModuleAST -> J.Position -> MaybeT m [J.Location]
+references store ast pos = do
+    -- Look up identifier under cursor
+    (symbols, _) <- liftMaybe $ resolveAtPos store ast pos
+    sequence $
+        [ currySpanInfo2Location spi
+        | symbol <- symbols
+        , (_, mse) <- M.toList store.modules
+        , (qid, spi) <- (withSpanInfo <$> qualIdentifiers mse.moduleAST)
+                     ++ (joinFst $ (maybeToList . qualIdentifier) <.$> withSpanInfo <$> expressions mse.moduleAST)
+        , let qid' = resolveQualIdent qid
+        , trace (T.unpack (ppToText qid) ++ " vs " ++ T.unpack symbol.qualIdent) (ppToText qid) == symbol.qualIdent
+        ]
+    where withSpanInfo x = (x, CSPI.getSpanInfo x)

--- a/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Curry.LanguageServer.Handlers.TextDocument.References (referencesHandler) where
+
+import Curry.LanguageServer.Monad (LSM)
+import qualified Language.LSP.Server as S
+import qualified Language.LSP.Protocol.Message as J
+import qualified Language.LSP.Protocol.Types as J
+import Curry.LanguageServer.Utils.Logging (debugM)
+
+referencesHandler :: S.Handlers LSM
+referencesHandler = S.requestHandler J.SMethod_TextDocumentReferences $ \req responder -> do
+    debugM "Processing references request"
+    responder $ Right $ J.InL []


### PR DESCRIPTION
### Fixes #11 

This implements the `textDocument/references` LSP method, which finds all uses of the selected symbol:

![Screenshot 2025-05-07 at 01 58 49](https://github.com/user-attachments/assets/56c590b1-2ba0-4038-8963-1933827425f3)

![Screenshot 2025-05-07 at 01 59 17](https://github.com/user-attachments/assets/35bc7c83-49c3-4fb3-9940-314ce5c3a577)
