### PR TITLE
Resolve local identifiers in definition lookups, hover etc.

### DIFF
--- a/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
+++ b/src/Curry/LanguageServer/Handlers/TextDocument/References.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans (MonadTrans (..))
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import qualified Curry.LanguageServer.Config as CFG
 import Curry.LanguageServer.Monad (LSM, getStore)
-import Curry.LanguageServer.Utils.Convert (ppToText, currySpanInfo2Location)
+import Curry.LanguageServer.Utils.Convert (currySpanInfo2Location)
 import Curry.LanguageServer.Utils.General (liftMaybe, (<.$>), joinFst)
 import Curry.LanguageServer.Utils.Logging (debugM, infoM)
 import Curry.LanguageServer.Utils.Sema (ModuleAST)

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -10,6 +10,7 @@ import qualified Curry.Base.Ident as CI
 import qualified Curry.Syntax as CS
 
 import Control.Applicative (Alternative ((<|>)))
+import Control.Monad (join)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
@@ -52,9 +53,10 @@ resolveLocalIdentAtPos ast pos = do
     range <- currySpanInfo2Range spi
     let symbols = [def { ident = ppToText lid
                        , qualIdent = ppToText lid
+                       , printedType = ppToText <$> join lty
                        , location = unsafePerformIO (runMaybeT (currySpanInfo2Location lid)) -- SAFETY: We expect this conversion to be pure
                        }
-                  | (lid, _) <- M.toList scope
+                  | (lid, lty) <- M.toList scope
                   , CI.idName lid == CI.idName (CI.qidIdent qid)
                   ]
     return (symbols, range)

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -56,7 +56,7 @@ resolveLocalIdentAtPos ast pos = do
                        , printedType = ppToText <$> join lty
                        , location = unsafePerformIO (runMaybeT (currySpanInfo2Location lid)) -- SAFETY: We expect this conversion to be pure
                        }
-                  | (lid, lty) <- M.toList scope
+                  | (_, (lid, lty)) <- M.toList scope
                   , CI.idName lid == CI.idName (CI.qidIdent qid)
                   ]
     -- Fail the computation when no local source identifier could be found

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -17,7 +17,7 @@ import qualified Curry.LanguageServer.Index.Symbol as I
 import Curry.LanguageServer.Index.Symbol (Symbol (..))
 import Curry.LanguageServer.Utils.Convert (currySpanInfo2Range, currySpanInfo2Location, ppToText)
 import Curry.LanguageServer.Utils.Sema (ModuleAST)
-import Curry.LanguageServer.Utils.Lookup (findQualIdentAtPos, findExprIdentAtPos, findModuleIdentAtPos, findScopeAtPos)
+import Curry.LanguageServer.Utils.Lookup (findQualIdentAtPos, findModuleIdentAtPos, findScopeAtPos)
 import qualified Language.LSP.Protocol.Types as J
 import Data.Default (Default(def))
 import qualified Data.Map as M
@@ -49,7 +49,7 @@ resolveModuleIdentAtPos store ast pos = do
 resolveLocalIdentAtPos :: ModuleAST -> J.Position -> Maybe ([I.Symbol], J.Range)
 resolveLocalIdentAtPos ast pos = do
     let scope = findScopeAtPos ast pos
-    (qid, spi) <- findExprIdentAtPos ast pos
+    (qid, spi) <- findQualIdentAtPos ast pos
     range <- currySpanInfo2Range spi
     let symbols = [def { ident = ppToText lid
                        , qualIdent = ppToText lid

--- a/src/Curry/LanguageServer/Index/Resolve.hs
+++ b/src/Curry/LanguageServer/Index/Resolve.hs
@@ -10,7 +10,7 @@ import qualified Curry.Base.Ident as CI
 import qualified Curry.Syntax as CS
 
 import Control.Applicative (Alternative ((<|>)))
-import Control.Monad (join)
+import Control.Monad (join, when)
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import qualified Curry.LanguageServer.Index.Store as I
 import qualified Curry.LanguageServer.Index.Symbol as I
@@ -59,6 +59,9 @@ resolveLocalIdentAtPos ast pos = do
                   | (lid, lty) <- M.toList scope
                   , CI.idName lid == CI.idName (CI.qidIdent qid)
                   ]
+    -- Fail the computation when no local source identifier could be found
+    when (null symbols)
+        Nothing
     return (symbols, range)
 
 -- | Resolves the qualified identifier at the given position.

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -2,6 +2,7 @@
 -- | Position lookup in the AST.
 module Curry.LanguageServer.Utils.Lookup
     ( findQualIdentAtPos
+    , findExprIdentAtPos
     , findModuleIdentAtPos
     , findTypeAtPos
     , findScopeAtPos
@@ -38,8 +39,12 @@ type Scope a = M.Map CI.Ident (Maybe a)
 findQualIdentAtPos :: CS.Module a -> J.Position -> Maybe (CI.QualIdent, CSPI.SpanInfo)
 findQualIdentAtPos ast pos = qualIdent <|> exprIdent <|> basicIdent
     where qualIdent = withSpanInfo <$> elementAt pos (qualIdentifiers ast)
-          exprIdent = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
+          exprIdent = findExprIdentAtPos ast pos
           basicIdent = CI.qualify <.$> withSpanInfo <$> elementAt pos (identifiers ast)
+
+--- | Finds expression identifier and (occurrence) span info at a given position.
+findExprIdentAtPos :: CS.Module a -> J.Position -> Maybe (CI.QualIdent, CSPI.SpanInfo)
+findExprIdentAtPos ast pos = joinFst $ qualIdentifier <.$> withSpanInfo <$> elementAt pos (expressions ast)
 
 -- | Finds module identifier and (occurrence) span info at a given position.
 findModuleIdentAtPos :: CS.Module a -> J.Position -> Maybe (CI.ModuleIdent, CSPI.SpanInfo)

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -75,7 +75,7 @@ bindInScopes _ _ _        = error "Cannot bind without a scope!"
 
 -- | Flattens the given scopes, preferring earlier binds.
 flattenScopes :: [Scope a] -> Scope a
-flattenScopes = foldr M.union M.empty
+flattenScopes = M.unions
 
 -- | Stores nested scopes and a cursor position. The head of the list is always the innermost collectScope.
 data ScopeState a = ScopeState

--- a/src/Curry/LanguageServer/Utils/Lookup.hs
+++ b/src/Curry/LanguageServer/Utils/Lookup.hs
@@ -81,8 +81,6 @@ bindInScopes _ _ _        = error "Cannot bind without a scope!"
 showScope :: Scope a -> String
 showScope = show . map (second (CP.line . CSPI.getStartPosition . CI.idSpanInfo . fst)) . M.toList
 
--- DEBUG: Remove Show
-
 -- | Flattens the given scopes, preferring earlier binds.
 flattenScopes :: [Scope a] -> Scope a
 flattenScopes = M.unions


### PR DESCRIPTION
### Fixes #84

This prepends a local variable lookup to the resolution mechanism, enabling go-to-definition, hover etc. on local variables.